### PR TITLE
top-level global declarations

### DIFF
--- a/spec/declaration/global_spec.lua
+++ b/spec/declaration/global_spec.lua
@@ -1,0 +1,83 @@
+local tl = require("tl")
+
+describe("global", function()
+   describe("undeclared", function()
+      it("fails for single assignment", function()
+         local tokens = tl.lex([[
+            x = 1
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         assert.same("unknown variable: x", errors[1].err)
+         assert.same(0, #unknowns)
+      end)
+
+      it("fails for multiple assignment", function()
+         local tokens = tl.lex([[
+            x, y = 1, 2
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         assert.same("unknown variable: x", errors[1].err)
+         assert.same("unknown variable: y", errors[2].err)
+         assert.same(0, #unknowns)
+      end)
+   end)
+
+   describe("declared at top level", function()
+      it("works for single assignment", function()
+         local tokens = tl.lex([[
+            x: number = 1
+            x = 2
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         assert.same({}, errors)
+         assert.same(0, #unknowns)
+      end)
+
+      it("works for multiple assignment", function()
+         local tokens = tl.lex([[
+            x, y: number, string = 1, "hello"
+            x = 2
+            y = "world"
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         assert.same({}, errors)
+         assert.same(#unknowns, 0)
+      end)
+   end)
+   describe("declared not at top level", function()
+      it("fails for single assignment", function()
+         local tokens = tl.lex([[
+            function foo()
+               x: number = 1
+               x = 2
+            end
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         assert.same(2, #errors)
+         assert.same(2, #errors)
+         assert.same("unknown variable: x", errors[1].err)
+         assert.same("unknown variable: x", errors[2].err)
+      end)
+
+      it("fails for multiple assignment", function()
+         local tokens = tl.lex([[
+            function foo()
+               x, y: number, string = 1, "hello"
+               x = 2
+               y = "world"
+            end
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors, unknowns = tl.type_check(ast)
+         -- FIXME this craps out a lot of weird errors!
+         assert.same(7, #errors)
+         assert.same(#unknowns, 0)
+      end)
+   end)
+
+end)

--- a/tl.tl
+++ b/tl.tl
@@ -660,7 +660,7 @@ local Node = record
 end
 
 local parse_expression: function({Token}, number, {ParseError}): number, Node, number
-local parse_statements: function({Token}, number, {ParseError}, string): number, Node
+local parse_statements: function({Token}, number, {ParseError}, string, boolean): number, Node
 local parse_type_list: function({Token}, number, {ParseError}, string): number, Type
 local parse_argument_list: function({Token}, number, {ParseError}): number, Node
 local parse_type: function({Token}, number, {ParseError}): number, Type, number
@@ -1498,36 +1498,76 @@ local is_newtype: {string:boolean} = {
    ["functiontype"] = true,
 }
 
-local function parse_call_or_assignment(tokens: {Token}, i: number, errs: {ParseError}): number, Node
+local function parse_assignment_rvalues(tokens: {Token}, i: number, errs: {ParseError}, asgn: Node): number, Node
+   asgn.exps = new_node(tokens, i, "values")
+   repeat
+      i = i + 1
+      local val: Node
+      if is_newtype[tokens[i].tk] then
+         if #asgn.vars > 1 then
+            return fail(tokens, i, errs, "cannot perform multiple assignment of type definitions")
+         end
+         i, val = parse_newtype(tokens, i, errs)
+      else
+         i, val = parse_expression(tokens, i, errs)
+      end
+      table.insert(asgn.exps, val)
+   until tokens[i].tk ~= ","
+   return i, asgn
+end
+
+local function parse_call_or_assignment(tokens: {Token}, i: number, errs: {ParseError}, toplevel: boolean): number, Node
    local asgn: Node = new_node(tokens, i, "assignment")
 
    asgn.vars = new_node(tokens, i, "variables")
+
+   local globals: Node
+   local errors_g: {ParseError} = {}
+   local ig: number = 0
+   if toplevel then
+      globals = new_node(tokens, i, "global_declaration")
+      globals.vars = new_node(tokens, i, "variables")
+      ig = parse_trying_list(tokens, i, errors_g, globals.vars, parse_local_variable)
+   end
+
    i = parse_trying_list(tokens, i, errs, asgn.vars, parse_expression)
    if #asgn.vars < 1 then
       return fail(tokens, i, errs)
    end
-   local lhs: Node = asgn.vars[1]
 
-   if tokens[i].tk == "=" then
-      asgn.exps = new_node(tokens, i, "values")
-      repeat
-         i = i + 1
-         local val: Node
-         if is_newtype[tokens[i].tk] then
-            if #asgn.vars > 1 then
-               return fail(tokens, i, errs, "cannot perform multiple assignment of type definitions")
-            end
-            i, val = parse_newtype(tokens, i, errs)
-         else
-            i, val = parse_expression(tokens, i, errs)
+   local colon = false
+   if toplevel then
+      for _, v in ipairs(asgn.vars) do
+         if v.op and v.op.op == ":" then
+            colon = true
+            break
          end
-         table.insert(asgn.exps, val)
-      until tokens[i].tk ~= ","
-      return i, asgn
+      end
    end
-   if lhs.op and lhs.op.op == "@funcall" then
+
+   if not colon and tokens[i].tk == "=" then
+      return parse_assignment_rvalues(tokens, i, errs, asgn)
+   end
+
+   local lhs: Node = asgn.vars[1]
+   if lhs.op and lhs.op.op == "@funcall" and #asgn.vars == 1 then
       return i, lhs
    end
+
+   if toplevel and colon then
+      if #errors_g == 0 and #globals.vars > 0 and tokens[ig].tk == ":" then
+         if tokens[ig + 1].tk == "=" then
+            ig = ig + 1
+         else
+            ig, globals.decltype = parse_type_list(tokens, ig, errs)
+         end
+         if tokens[ig].tk == "=" then
+            return parse_assignment_rvalues(tokens, ig, errs, globals)
+         end
+         return ig, globals
+      end
+   end
+
    return fail(tokens, i, errs)
 end
 
@@ -1562,7 +1602,7 @@ local function parse_local_variables(tokens: {Token}, i: number, errs: {ParseErr
    return i, asgn
 end
 
-local function parse_statement(tokens: {Token}, i: number, errs: {ParseError}): number, Node
+local function parse_statement(tokens: {Token}, i: number, errs: {ParseError}, toplevel: boolean): number, Node
    if tokens[i].tk == "local" then
       if tokens[i+1].tk == "function" then
          return parse_local_function(tokens, i, errs)
@@ -1587,19 +1627,19 @@ local function parse_statement(tokens: {Token}, i: number, errs: {ParseError}): 
    elseif tokens[i].tk == "return" then
       return parse_return(tokens, i, errs)
    else
-      return parse_call_or_assignment(tokens, i, errs)
+      return parse_call_or_assignment(tokens, i, errs, toplevel)
    end
    return fail(tokens, i, errs)
 end
 
-parse_statements = function(tokens: {Token}, i: number, errs: {ParseError}, filename: string): number, Node
+parse_statements = function(tokens: {Token}, i: number, errs: {ParseError}, filename: string, toplevel: boolean): number, Node
    local node = new_node(tokens, i, "statements")
    while tokens[i].kind ~= "$EOF$" do
       if stop_statement_list[tokens[i].tk] then
          break
       end
       local item: Node
-      i, item = parse_statement(tokens, i, errs)
+      i, item = parse_statement(tokens, i, errs, toplevel)
       if filename then
          for j = 1, #errs do
             errs[j].filename = filename
@@ -1617,7 +1657,7 @@ function tl.parse_program(tokens: {Token}, errs: {ParseError}, filename: string)
    errs = errs or {}
    local last = tokens[#tokens]
    table.insert(tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
-   return parse_statements(tokens, 1, errs, filename)
+   return parse_statements(tokens, 1, errs, filename, true)
 end
 
 --------------------------------------------------------------------------------
@@ -1691,6 +1731,7 @@ local function recurse_node(ast: Node, visit_node: {string:VisitorCallbacks<Node
          xs[i] = recurse_node(child, visit_node, visit_type)
       end
    elseif ast.kind == "local_declaration"
+          or ast.kind == "global_declaration"
           or ast.kind == "assignment" then
       xs[1] = recurse_node(ast.vars, visit_node, visit_type)
       if ast.exps then
@@ -2234,6 +2275,8 @@ function tl.pretty_print_ast(ast: Node): string
    visit_node["values"] = visit_node["variables"]
    visit_node["expression_list"] = visit_node["variables"]
    visit_node["argument_list"] = visit_node["variables"]
+
+   visit_node["global declaration"] = visit_node["assignment"]
 
    visit_node["word"] = visit_node["variable"]
    visit_node["string"] = visit_node["variable"]
@@ -2861,6 +2904,13 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
          if scope[name] then
             return scope[name].t, scope[name].is_const
          end
+      end
+   end
+
+   local function find_global(name: string): Type, boolean
+      local scope = st[1]
+      if scope[name] then
+         return scope[name].t, scope[name].is_const
       end
    end
 
@@ -3535,6 +3585,34 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
                   end
                end
                add_var(var.tk, t, var.is_const)
+            end
+            node.type = { typename = "none" }
+         end,
+      },
+      ["global_declaration"] = {
+         after = function(node: Node, children: {Type}): Type
+            local vals: {Type} = get_assignment_values(children[2], #node.vars)
+            for i, var in ipairs(node.vars) do
+               local decltype = node.decltype and node.decltype[i]
+               local infertype = vals and vals[i]
+               if decltype and infertype then
+                  assert_is_a(node.vars[i], infertype, decltype, {}, "global declaration")
+               end
+               local t = decltype or infertype
+               local existing = find_global(var.tk)
+               if existing then
+                  if not same_type(existing, t) then
+                     table.insert(errors, { y = node.y, x = node.x, err = "cannot redeclare global with a different type: previous type of " .. var.tk .. " is " .. show_type(existing), filename = filename })
+                  end
+               else
+                  if t == nil then
+                     t = { typename = "unknown" }
+                     if lax then
+                       table.insert(unknowns, { y = node.y, x = node.x, name = var.tk, filename = filename })
+                     end
+                  end
+                  add_global(var.tk, t, var.is_const)
+               end
             end
             node.type = { typename = "none" }
          end,


### PR DESCRIPTION
For declaring globals, should I be doing contortions to parse ambiguous syntax like

```
x: T
```

at the toplevel and detect it as a global declaration or should I just add a new `global` keyword for global declarations? This PR does the ambiguous-syntax handling option for toplevel globals, but it produces some weird error messages in case of misuse.

I think I'll drop this and go with the `global` keyword, but this is the code of the other version.