### PR TITLE
Add support for loading .d.tl files as definition files

### DIFF
--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -13,6 +13,55 @@ describe("local function", function()
       assert.same({}, errors)
    end)
 
+   it("declaration with nil as return", function()
+      local tokens = tl.lex([[
+         local function f(a: number, b: string): nil
+            return
+         end
+         local ok = f(3, "abc")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same({}, errors)
+   end)
+
+   it("declaration with no return", function()
+      local tokens = tl.lex([[
+         local function f(a: number, b: string): ()
+            return
+         end
+         f(3, "abc")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same({}, errors)
+   end)
+
+   it("declaration with no return cannot be used in assignment", function()
+      local tokens = tl.lex([[
+         local function f(a: number, b: string): ()
+            return
+         end
+         local x = f(3, "abc")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same(1, #errors)
+      assert.same("assignment in declaration did not produce an initial value for variable 'x'", errors[1].msg)
+   end)
+
+   it("declaration with return nil can be used in assignment", function()
+      local tokens = tl.lex([[
+         local function f(a: number, b: string): nil
+            return
+         end
+         local x = f(3, "abc")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same(0, #errors)
+   end)
+
    describe("with function arguments", function()
       it("has ambiguity without parentheses in function type return", function()
          local tokens = tl.lex([[

--- a/tl.lua
+++ b/tl.lua
@@ -1025,6 +1025,7 @@ end
 parse_type = function(tokens, i, errs)
    if tokens[i].tk == "string" or
       tokens[i].tk == "boolean" or
+      tokens[i].tk == "nil" or
       tokens[i].tk == "number" then
       return i + 1, {
          ["y"] = tokens[i].y,
@@ -3484,7 +3485,7 @@ function tl.type_check(ast, lax, filename, modules, result, globals, compat53_re
          return true
       end
 
-      if t1.typename == "nil" or t2.typename == "nil" then
+      if t1.typename == "nil" then
          return true
       end
 
@@ -4104,7 +4105,11 @@ function tl.type_check(ast, lax, filename, modules, result, globals, compat53_re
                   if lax then
                      add_unknown(node, var.tk)
                   else
-                     node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
+                     if node.exps then
+                        node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. var.tk .. "'")
+                     else
+                        node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
+                     end
                   end
                elseif t.typename == "emptytable" then
                   t.declared_at = node

--- a/tl.lua
+++ b/tl.lua
@@ -2759,7 +2759,7 @@ local Result = {}
 
 
 
-function tl.search_module(module_name)
+function tl.search_module(module_name, search_dtl)
    local found
    local fd
    local tried = {}
@@ -2775,6 +2775,17 @@ function tl.search_module(module_name)
             break
          end
          table.insert(tried, "no file '" .. tl_filename .. "'")
+      end
+      if search_dtl then
+         local dtl_filename = filename:gsub("%.lua$", ".d.tl")
+         if dtl_filename ~= filename then
+            fd = io.open(dtl_filename, "r")
+            if fd then
+               found = dtl_filename
+               break
+            end
+            table.insert(tried, "no file '" .. dtl_filename .. "'")
+         end
       end
       fd = io.open(filename, "r")
       if fd then
@@ -4029,7 +4040,7 @@ function tl.type_check(ast, lax, filename, modules, result, globals, compat53_re
       end
       modules[module_name] = UNKNOWN
 
-      local found, fd, tried = tl.search_module(module_name)
+      local found, fd, tried = tl.search_module(module_name, true)
       if found and (lax or found:match("tl$")) then
          fd:close()
          local _result, err = tl.process(found, modules, result, st[1])
@@ -4732,7 +4743,7 @@ function tl.process(filename, modules, result, globals)
 end
 
 local function tl_package_loader(module_name)
-   local found_filename, fd, tried = tl.search_module(module_name)
+   local found_filename, fd, tried = tl.search_module(module_name, false)
    if found_filename then
       local input = fd:read("*a")
       fd:close()

--- a/tl.tl
+++ b/tl.tl
@@ -1025,6 +1025,7 @@ end
 parse_type = function(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
    if tokens[i].tk == "string"
       or tokens[i].tk == "boolean"
+      or tokens[i].tk == "nil"
       or tokens[i].tk == "number" then
       return i + 1, {
          y = tokens[i].y,
@@ -3484,7 +3485,7 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
          return true
       end
 
-      if t1.typename == "nil" or t2.typename == "nil" then -- TODO nilable
+      if t1.typename == "nil" then -- TODO nilable
          return true
       end
 
@@ -4104,7 +4105,11 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
                   if lax then
                      add_unknown(node, var.tk)
                   else
-                     node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
+                     if node.exps then
+                        node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. var.tk .. "'")
+                     else
+                        node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
+                     end
                   end
                elseif t.typename == "emptytable" then
                   t.declared_at = node

--- a/tl.tl
+++ b/tl.tl
@@ -2759,7 +2759,7 @@ local Result = record
    unknowns: {Error}
 end
 
-function tl.search_module(module_name: string): string, FILE, {string}
+function tl.search_module(module_name: string, search_dtl: boolean): string, FILE, {string}
    local found: string
    local fd: FILE
    local tried: {string} = {}
@@ -2775,6 +2775,17 @@ function tl.search_module(module_name: string): string, FILE, {string}
             break
          end
          table.insert(tried, "no file '" .. tl_filename .. "'")
+      end
+      if search_dtl then
+         local dtl_filename = filename:gsub("%.lua$", ".d.tl")
+         if dtl_filename ~= filename then
+            fd = io.open(dtl_filename, "r")
+            if fd then
+               found = dtl_filename
+               break
+            end
+            table.insert(tried, "no file '" .. dtl_filename .. "'")
+         end
       end
       fd = io.open(filename, "r")
       if fd then
@@ -4029,7 +4040,7 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
       end
       modules[module_name] = UNKNOWN
 
-      local found, fd, tried = tl.search_module(module_name)
+      local found, fd, tried = tl.search_module(module_name, true)
       if found and (lax or found:match("tl$") as boolean) then
          fd:close()
          local _result, err: Result, string = tl.process(found, modules, result, st[1])
@@ -4732,7 +4743,7 @@ function tl.process(filename: string, modules: {string:Type}, result: Result, gl
 end
 
 local function tl_package_loader(module_name: string): any
-   local found_filename, fd, tried = tl.search_module(module_name)
+   local found_filename, fd, tried = tl.search_module(module_name, false)
    if found_filename then
       local input = fd:read("*a")
       fd:close()


### PR DESCRIPTION
When type checking, `require("foo")` will search for:

* `foo.tl` first
* then `foo.d.tl`
* and finally `foo.lua`

This means that if a `.d.tl` definitions file exists,
it will be used as a stand-in for a Lua module, and the
`.lua` file contents will be ignored when typechecking.

When running code, we do not read `.d.tl` files, and just check

* `foo.tl` first
* and finally `foo.lua`

This means that if a Lua module has a pair of files `foo.d.tl`
and `foo.lua`, the `.d.tl` file will be used for typechecking
and the `.lua` file will be used for running. It is the user's
responsibility to ensure that these two files match -- for now
we perform no cross-checking between them.