### PR TITLE
Accept parameter names inside function declarations

### DIFF
--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -1,6 +1,64 @@
 local tl = require("tl")
 
 describe("local function", function()
+   describe("type", function()
+      it("can have anonymous arguments", function()
+         local tokens = tl.lex([[
+            local f: function(number, string): boolean
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("can take names in arguments but names are ignored", function()
+         local tokens = tl.lex([[
+            local f: function(x: number, y: string): boolean
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("can take typed vararg in arguments", function()
+         local tokens = tl.lex([[
+            local f: function(x: number, ...: string): boolean
+
+            f = function(a: number, ...: string): boolean
+               return #select(1, ...) == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("cannot take untyped vararg", function()
+         local tokens = tl.lex([[
+            local f: function(number, ...): boolean
+
+            f = function(a: number, ...: string): boolean
+               return #select(1, ...) == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local syntax_errors = {}
+         local _ = tl.parse_program(tokens, syntax_errors)
+         assert.same("cannot have untyped '...' when declaring the type of an argument", syntax_errors[1].msg)
+      end)
+   end)
+
    it("declaration", function()
       local tokens = tl.lex([[
          local function f(a: number, b: string): boolean

--- a/tl.tl
+++ b/tl.tl
@@ -837,6 +837,7 @@ local parse_expression: function({Token}, number, {ParseError}): number, Node, n
 local parse_statements: function({Token}, number, {ParseError}, string): number, Node
 local parse_type_list: function({Token}, number, {ParseError}, string): number, Type
 local parse_argument_list: function({Token}, number, {ParseError}): number, Node
+local parse_argument_type_list: function({Token}, number, {ParseError}): number, Type
 local parse_type: function({Token}, number, {ParseError}): number, Type, number
 
 
@@ -990,8 +991,7 @@ local function parse_function_type(tokens: {Token}, i: number, errs: {ParseError
       rets = {},
    }
    if tokens[i].tk == "(" then
-      i, node.args = parse_type_list(tokens, i, errs, "(")
-      i = verify_tk(tokens, i, errs, ")")
+      i, node.args = parse_argument_type_list(tokens, i, errs)
       i, node.rets = parse_type_list(tokens, i, errs)
    else
       node.args = { { typename = "any", is_va = true } }
@@ -1344,6 +1344,32 @@ end
 parse_argument_list = function(tokens: {Token}, i: number, errs: {ParseError}): number, Node
    local node = new_node(tokens, i, "argument_list")
    return parse_bracket_list(tokens, i, errs, node, "(", ")", true, parse_argument)
+end
+
+local function parse_argument_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
+   local is_va = false
+   if tokens[i].kind == "identifier" and tokens[i + 1].tk == ":" then
+      i = i + 2
+   elseif tokens[i].tk == "..." then
+      if tokens[i + 1].tk == ":" then
+         i = i + 2
+         is_va = true
+      else
+         return fail(tokens, i, errs, "cannot have untyped '...' when declaring the type of an argument")
+      end
+   end
+
+   local i, typ = parse_type(tokens, i, errs)
+   if typ then
+      typ.is_va = is_va
+   end
+
+   return i, typ, 0
+end
+
+parse_argument_type_list = function(tokens: {Token}, i: number, errs: {ParseError}): number, Type
+   local list = new_type(tokens, i, "type_list")
+   return parse_bracket_list(tokens, i, errs, list, "(", ")", true, parse_argument_type)
 end
 
 local function parse_local_function(tokens: {Token}, i: number, errs: {ParseError}): number, Node


### PR DESCRIPTION
Fixes #32.

From @pdesaulniers:

>> I think parameter names inside function declarations should be allowed. It
>> would make writing declaration files a bit easier. Also, text editors would be
>> able to parse declaration files and show parameter names in tooltips.

to which I replied:

> I agree! I've been annoyed myself by this at times. And also I just realized
> that the syntax with form `<name>: <type>` in function declarations is needed
> in varargs, to allow for `...: string` and the like.