### PR TITLE
overloading functions in records produces a poly type

### DIFF
--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -1,0 +1,35 @@
+local tl = require("tl")
+
+describe("record", function()
+   it("can overload functions", function()
+      local tokens = tl.lex([[
+         global love_graphics = record
+            print: function(text: string, x: number, y: number, r: number, sx: number, sy: number, ox: number, oy: number, kx: number, ky:number)
+            print: function(coloredtext: {any}, x: number, y: number, r: number, sx: number, sy: number, ox: number, oy: number, kx: number, ky:number)
+         end
+
+         global love = record
+            graphics: love_graphics
+         end
+
+         function main()
+            love.graphics.print("Hello world", 100, 100)
+         end
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same({}, errors)
+   end)
+   it("cannot overload other things", function()
+      local tokens = tl.lex([[
+         global love_graphics = record
+            print: number
+            print: string
+         end
+      ]])
+      local syntax_errors = {}
+      local _, ast = tl.parse_program(tokens, syntax_errors)
+      assert.same("attempt to redeclare field 'print' (only functions can be overloaded)", syntax_errors[1].msg)
+   end)
+
+end)

--- a/tl.tl
+++ b/tl.tl
@@ -1592,8 +1592,22 @@ local function parse_newtype(tokens: {Token}, i: number, errs: {ParseError}): nu
             if not t then
                return fail(tokens, i, errs, "expected a type")
             end
-            def.fields[v.tk] = t
-            table.insert(def.field_order, v.tk)
+            if not def.fields[v.tk] then
+               def.fields[v.tk] = t
+               table.insert(def.field_order, v.tk)
+            else
+               local prev_t = def.fields[v.tk]
+               if t.typename == "function" and prev_t.typename == "function" then
+                  def.fields[v.tk] = {
+                     typename = "poly",
+                     poly = { prev_t, t }
+                  }
+               elseif t.typename == "function" and prev_t.typename == "poly" then
+                  table.insert(prev_t.poly, t)
+               else
+                  return fail(tokens, i, errs, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+               end
+            end
          end
       end
       node.yend = tokens[i].y
@@ -1692,7 +1706,11 @@ local function parse_variable_declarations(tokens: {Token}, i: number, errs: {Pa
                return fail(tokens, i, errs, "cannot perform multiple assignment of type definitions")
             end
             i, val = parse_newtype(tokens, i, errs)
-            val.newtype.def.name = asgn.vars[v].tk
+            if val then
+               val.newtype.def.name = asgn.vars[v].tk
+            else
+               return i, val
+            end
          else
             i, val = parse_expression(tokens, i, errs)
          end


### PR DESCRIPTION
This should be useful for type declaration files, and exposes a "transparent" way of producing `poly`-function types of the like that I've been using to declare the standard library internally.

Fixes #36.