### PR TITLE
Allow preloading modules

### DIFF
--- a/spec/preload/preload_spec.lua
+++ b/spec/preload/preload_spec.lua
@@ -1,0 +1,85 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("preload", function()
+   it("exports global types", function ()
+      -- ok
+      util.mock_io(finally, {
+         ["love.d.tl"] = [[
+            global love_graphics = record
+               print: function(text: string)
+            end
+
+            global love = record
+               graphics: love_graphics
+            end
+         ]],
+         ["foo.tl"] = [[
+            function love.draw()
+               love.graphics.print("<3")
+            end
+         ]],
+      })
+
+      local result, err = tl.process("foo.tl", nil, nil, nil, {"love"})
+
+      assert.same(nil, err)
+      assert.same(0, #result.syntax_errors)
+      assert.same(0, #result.type_errors)
+      assert.same(0, #result.unknowns)
+   end)
+   it("can require multiple modules", function()
+      -- ok
+      util.mock_io(finally, {
+         ["love.d.tl"] = [[
+            global love_graphics = record
+               print: function(text: string)
+            end
+
+            global love = record
+               graphics: love_graphics
+            end
+         ]],
+         ["hate.d.tl"] = [[
+            global hate_graphics = record
+               print: function(text: string)
+            end
+
+            global hate = record
+               graphics: hate_graphics
+            end
+         ]],
+         ["foo.tl"] = [[
+            function love.draw()
+               love.graphics.print("<3")
+            end
+
+            function hate.draw()
+               hate.graphics.print(">:(")
+            end
+         ]],
+      })
+
+      local result, err = tl.process("foo.tl", nil, nil, nil, {"love", "hate"})
+
+      assert.same(nil, err)
+      assert.same(0, #result.syntax_errors)
+      assert.same(0, #result.type_errors)
+      assert.same(0, #result.unknowns)
+   end)
+   it("returns an error when a module doesn't exist", function ()
+      -- ok
+      util.mock_io(finally, {
+         ["foo.tl"] = [[
+            function love.draw()
+               love.graphics.print("<3")
+            end
+         ]],
+      })
+
+      local result, err = tl.process("foo.tl", nil, nil, nil, {"love"})
+
+      assert.same(nil, result)
+      assert.is_not_nil(err)
+    end)
+end)

--- a/tl
+++ b/tl
@@ -5,9 +5,53 @@ local function script_path()
    return str:match("(.*[/\\])") or "."
 end
 
+-- FIXME
+local function validate_config(config)
+   local valid_keys = {
+      preload_modules = true
+   }
+
+   for k, _ in pairs(config) do
+      if not valid_keys[k] then
+         print(string.format("Warning: unknown key '%s' in tlconfig.lua", k))
+      end
+   end
+
+   -- TODO: could we type-check the config file using tl?
+
+   return nil
+end
+
+local function get_config()
+   local config = {
+      preload_modules = {}
+   }
+
+   local status, user_config = pcall(require, "tlconfig")
+
+   if not status then
+      return config
+   end
+
+   -- Merge tlconfig with the default config
+   for k, v in pairs(user_config) do
+      config[k] = v
+   end
+
+   local err = validate_config(config)
+
+   if err then
+      die("Error while loading config: " .. err)
+   end
+
+   return config
+end
+
 package.path = script_path() .. "/?.lua;" .. package.path
 
 local tl = require("tl")
+
+local tlconfig = get_config()
 
 local cmd
 local filename
@@ -68,7 +112,7 @@ local function die(msg)
    os.exit(1)
 end
 
-local result, err = tl.process(filename)
+local result, err = tl.process(filename, nil, nil, nil, tlconfig["preload_modules"])
 if err then
    die(err)
 end

--- a/tl.lua
+++ b/tl.lua
@@ -3145,13 +3145,14 @@ local function add_compat53_entries(program, used_set)
    program.y = 1
 end
 
-function tl.type_check(ast, lax, filename, modules, result, globals, compat53_recursion)
+function tl.type_check(ast, lax, filename, modules, result, globals, compat53_recursion, preload_modules)
    modules = modules or {}
    result = result or {
       ["syntax_errors"] = {},
       ["type_errors"] = {},
       ["unknowns"] = {},
    }
+   preload_modules = preload_modules or {}
 
    local stdlib_compat53 = {}
    if lax then
@@ -4100,6 +4101,18 @@ function tl.type_check(ast, lax, filename, modules, result, globals, compat53_re
       return old
    end
 
+   for _, module_name in ipairs(preload_modules) do
+      local module_type = require_module(module_name, result)
+
+      assert(module_type ~= UNKNOWN, string.format("Error: could not preload module '%s'", module_name))
+
+      if not module_type then
+         module_type = BOOLEAN
+      end
+
+      modules[module_name] = module_type
+   end
+
    local visit_node = {}
 
    visit_node.cbs = {
@@ -4727,7 +4740,7 @@ local function init_modules()
    return modules
 end
 
-function tl.process(filename, modules, result, globals)
+function tl.process(filename, modules, result, globals, preload_modules)
    modules = modules or init_modules()
    result = result or {
       ["syntax_errors"] = {},
@@ -4766,7 +4779,7 @@ function tl.process(filename, modules, result, globals)
    local is_lua = filename:match("%.lua$") ~= nil
 
    local error, unknown
-   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals)
+   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals, false, preload_modules)
 
    result.ast = program
 

--- a/tl.tl
+++ b/tl.tl
@@ -3145,13 +3145,14 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
    program.y = 1
 end
 
-function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, compat53_recursion: boolean): {Error}, {Error}, Type
+function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, compat53_recursion: boolean, preload_modules: {string}): {Error}, {Error}, Type
    modules = modules or {}
    result = result or {
       syntax_errors = {},
       type_errors = {},
       unknowns = {},
    }
+   preload_modules = preload_modules or {}
 
    local stdlib_compat53: {string:boolean} = {}
    if lax then
@@ -4100,6 +4101,18 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
       return old
    end
 
+   for _, module_name in ipairs(preload_modules) do
+      local module_type = require_module(module_name, result)
+
+      assert(module_type ~= UNKNOWN, string.format("Error: could not preload module '%s'", module_name))
+
+      if not module_type then
+         module_type = BOOLEAN
+      end
+
+      modules[module_name] = module_type
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -4727,7 +4740,7 @@ local function init_modules(): {string:Type}
    return modules
 end
 
-function tl.process(filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}): Result, string
+function tl.process(filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, preload_modules: {string}): Result, string
    modules = modules or init_modules()
    result = result or {
       syntax_errors = {},
@@ -4766,7 +4779,7 @@ function tl.process(filename: string, modules: {string:Type}, result: Result, gl
    local is_lua = filename:match("%.lua$") ~= nil
 
    local error, unknown: {Error}, {Error}
-   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals)
+   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals, false, preload_modules)
 
    result.ast = program
 

--- a/tl.tl
+++ b/tl.tl
@@ -2840,6 +2840,24 @@ local function fill_field_order(t: Type)
    end
 end
 
+local function require_module(module_name: string, lax: boolean, modules: {string:Type}, result: Result, globals: {string:Variable}): Type
+   if modules[module_name] then
+      return modules[module_name]
+   end
+   modules[module_name] = UNKNOWN
+
+   local found, fd, tried = tl.search_module(module_name, true)
+   if found and (lax or found:match("tl$") as boolean) then
+      fd:close()
+      local _result, err: Result, string = tl.process(found, modules, result, globals)
+      assert(_result, err)
+
+      return _result.type
+   end
+
+   return UNKNOWN
+end
+
 local standard_library: {string:Type} = {
    ["..."] = { typename = "tuple", STRING, STRING, STRING, STRING, STRING },
    ["@return"] = { typename = "tuple", ANY },
@@ -3145,22 +3163,13 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
    program.y = 1
 end
 
-function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, compat53_recursion: boolean, preload_modules: {string}): {Error}, {Error}, Type
-   modules = modules or {}
-   result = result or {
-      syntax_errors = {},
-      type_errors = {},
-      unknowns = {},
-   }
-   preload_modules = preload_modules or {}
-
-   local stdlib_compat53: {string:boolean} = {}
+local function get_stdlib_compat53(lax: boolean): {string:boolean}
    if lax then
-      stdlib_compat53 = {
+      return {
          ["utf8"] = true,
       }
    else
-      stdlib_compat53 = {
+      return {
          ["io"] = true,
          ["math"] = true,
          ["string"] = true,
@@ -3180,16 +3189,31 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
          ["rawlen"] = true,
       }
    end
+end
 
-   local st: {{string:Variable}}
-   if globals then
-      st = { globals }
-   else
-      st = {{}}
-      for name, typ in pairs(standard_library) do
-         st[1][name] = { t = typ, needs_compat53 = stdlib_compat53[name], is_const = true }
-      end
+local function init_globals(lax: boolean): {string:Variable}
+   local globals = {}
+   local stdlib_compat53 = get_stdlib_compat53(lax)
+
+   for name, typ in pairs(standard_library) do
+      globals[name] = { ["t"] = typ, ["needs_compat53"] = stdlib_compat53[name], ["is_const"] = true, }
    end
+
+   return globals
+end
+
+function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, compat53_recursion: boolean): {Error}, {Error}, Type
+   modules = modules or {}
+   result = result or {
+      syntax_errors = {},
+      type_errors = {},
+      unknowns = {},
+   }
+   globals = globals or init_globals()
+
+   local stdlib_compat53 = get_stdlib_compat53(lax)
+
+   local st: {{string:Variable}} = { globals }
 
    local all_needs_compat53 = {}
 
@@ -4062,24 +4086,6 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
       end
    end
 
-   local function require_module(module_name: string, result: Result): Type
-      if modules[module_name] then
-         return modules[module_name]
-      end
-      modules[module_name] = UNKNOWN
-
-      local found, fd, tried = tl.search_module(module_name, true)
-      if found and (lax or found:match("tl$") as boolean) then
-         fd:close()
-         local _result, err: Result, string = tl.process(found, modules, result, st[1])
-         assert(_result, err)
-
-         return _result.type
-      end
-
-      return UNKNOWN
-   end
-
    local function expand_type(old: Type, new: Type): Type
       if not old then
          return new
@@ -4099,18 +4105,6 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
          end
       end
       return old
-   end
-
-   for _, module_name in ipairs(preload_modules) do
-      local module_type = require_module(module_name, result)
-
-      assert(module_type ~= UNKNOWN, string.format("Error: could not preload module '%s'", module_name))
-
-      if not module_type then
-         module_type = BOOLEAN
-      end
-
-      modules[module_name] = module_type
    end
 
    local visit_node: Visitor<NodeKind, Node, Type> = {}
@@ -4495,7 +4489,7 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
                   if #b == 1 then
                      if node.e2[1].kind == "string" then
                         local module_name = assert(node.e2[1].conststr)
-                        node.type = require_module(module_name, result)
+                        node.type = require_module(module_name, lax, modules, result, st[1])
                         if not node.type then
                            node.type = BOOLEAN
                         end
@@ -4741,12 +4735,16 @@ local function init_modules(): {string:Type}
 end
 
 function tl.process(filename: string, modules: {string:Type}, result: Result, globals: {string:Variable}, preload_modules: {string}): Result, string
+   local is_lua = filename:match("%.lua$") ~= nil
+
    modules = modules or init_modules()
    result = result or {
       syntax_errors = {},
       type_errors = {},
       unknowns = {},
    }
+   globals = globals or init_globals(is_lua)
+   preload_modules = preload_modules or {}
 
    local fd, err = io.open(filename, "r")
    if not fd then
@@ -4776,10 +4774,23 @@ function tl.process(filename: string, modules: {string:Type}, result: Result, gl
       return result
    end
 
-   local is_lua = filename:match("%.lua$") ~= nil
+   -- Preload modules
+   for _, module_name in ipairs(preload_modules) do
+      local module_type = require_module(module_name, is_lua, modules, result, globals)
+
+      if module_type == UNKNOWN then
+         return nil, string.format("Error: could not preload module '%s'", module_name)
+      end
+
+      if not module_type then
+         module_type = BOOLEAN
+      end
+
+      modules[module_name] = module_type
+   end
 
    local error, unknown: {Error}, {Error}
-   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals, false, preload_modules)
+   error, unknown, result.type = tl.type_check(program, is_lua, filename, modules, result, globals)
 
    result.ast = program
 


### PR DESCRIPTION
Initilal work on https://github.com/hishamhm/tl/issues/35.

We can determine which modules to pre-load by setting the `preload_modules` key inside `tlconfig.lua`:
```lua
return {
	-- Execute the equivalent of `require('modulename')` before executing the script.
	preload_modules = {
		"definitions.love"
	}
}
```

I have not implemented the `-lmodule` command-line option yet.