### PR TITLE
Stricter booleans

### DIFF
--- a/spec/arguments/boolean_spec.lua
+++ b/spec/arguments/boolean_spec.lua
@@ -1,0 +1,50 @@
+local util = require("spec.util")
+util.init(it)
+
+describe("boolean argument", function()
+   util.check("accepts a boolean", [[
+      local function f(b: boolean)
+         if b then
+            print("I'm true!")
+         end
+      end
+
+      f(true)
+      f(false)
+   ]])
+
+   util.check("accepts nil", [[
+      local function f(b: boolean)
+         if b then
+            print("I'm true!")
+         end
+      end
+
+      f(nil)
+   ]])
+
+   util.check_type_error("rejects non-booleans", [[
+      local function f(b: boolean)
+         if b then
+            print("I'm true!")
+         end
+      end
+
+      local R = record
+         b: boolean
+      end
+      local r: R = {}
+
+      f("hello")
+      f(123)
+      f({})
+      f(r)
+      f(function() end)
+   ]], {
+      { y = 12, msg = 'argument 1: got string "hello", expected boolean' },
+      { y = 13, msg = 'argument 1: got number, expected boolean' },
+      { y = 14, msg = 'argument 1: got {}, expected boolean' },
+      { y = 15, msg = 'argument 1: got R, expected boolean' },
+      { y = 16, msg = 'argument 1: got function(), expected boolean' },
+   })
+end)

--- a/spec/statement/if_spec.lua
+++ b/spec/statement/if_spec.lua
@@ -1,0 +1,71 @@
+local util = require("spec.util")
+
+describe("if", function()
+   util.init(it)
+
+   util.check("accepts a boolean", [[
+      local b = true
+      if b then
+         print(b)
+      end
+   ]])
+
+   util.check("accepts a non-boolean", [[
+      local n = 123
+      if n then
+         print(n)
+      end
+   ]])
+
+   util.check("accepts boolean expressions", [[
+      local s = "Hallo, Welt"
+      if string.match(s, "world") or s == "Hallo, Welt" then
+         print(s)
+      end
+   ]])
+
+   util.check("accepts boolean expressions in elseif", [[
+      local s = "Hallo, Welt"
+      if 1 == 2 then
+         print("wat")
+      elseif string.match(s, "world") or s == "Hallo, Welt" then
+         print(s)
+      end
+   ]])
+
+   util.check("accepts non-boolean expressions", [[
+      local s = "Hello, world"
+      if string.match(s, "world") then
+         print(s)
+      end
+   ]])
+
+   util.check("accepts non-boolean expressions in elseif", [[
+      local s = "Hello, world"
+      if 1 == 2 then
+         print("wat")
+      elseif string.match(s, "world") then
+         print(s)
+      end
+   ]])
+
+   util.check_type_error("rejects a bad expression", [[
+      local x = 12
+      if not x == 123 then
+         print(x)
+      end
+   ]], {
+      { msg = "types are not comparable for equality: boolean and number" }
+   })
+
+   util.check_type_error("rejects a bad expression in else if", [[
+      local x = 12
+      if x == 123 then
+         print(x)
+      if not x == 123 then
+         print("not " .. x)
+      end
+   ]], {
+      { msg = "types are not comparable for equality: boolean and number" }
+   })
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -3724,7 +3724,8 @@ function tl.type_check(ast, lax, filename, modules, result, globals, skip_compat
          else
             return false, all_errs
          end
-      elseif (not for_equality) and t2.typename == "boolean" then
+      elseif lax and ((not for_equality) and t2.typename == "boolean") then
+
          return true
       elseif t1.typename == t2.typename then
          return true

--- a/tl.tl
+++ b/tl.tl
@@ -3724,7 +3724,8 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
          else
             return false, all_errs
          end
-      elseif (not for_equality) and t2.typename == "boolean" then -- all values can be used in a boolean context (but not in == or ~=)
+      elseif lax and ((not for_equality) and t2.typename == "boolean") then
+         -- in .lua files, all values can be used in a boolean context (but not in == or ~=)
          return true
       elseif t1.typename == t2.typename then
          return true


### PR DESCRIPTION
Every Lua value can be used in a boolean context because nil is falsy and all
other values are truthy. For this reason, originally tl accepted any value as
booleans (except in equality comparisons, where they are usually bugs, because
doing things like `x == true` where `x` is not a boolean is always `false`).

However, this can hide bugs, such as passing incorrect arguments to functions.
Let's make tl stricter about this and require real booleans in context where
they are asked for. We will still accept non-booleans in `if` statements
and logical operators since these are common idioms (and tl propagates their
types correctly).

For now we will still accept non-booleans in boolean arguments in .lua files
(lax mode).

Fixes #44.

(Bonus: added a few functions in `spec.util` to make writing tests a bit shorter)