### PR TITLE
disallow extending records with functions outside of original scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
 	./tl tl.tl
 	cp tl.lua tl.lua.bak
-	./tl gen tl.tl && cp tl.lua tl.lua.1 || { cp tl.lua.bak tl.lua; exit 1; }
-	./tl gen tl.tl && cp tl.lua tl.lua.2 || { cp tl.lua.bak tl.lua; exit 1; }
+	./tl gen tl.tl && cp tl.lua tl.lua.1 || { cp tl.lua tl.lua.1; cp tl.lua.bak tl.lua; exit 1; }
+	./tl gen tl.tl && cp tl.lua tl.lua.2 || { cp tl.lua tl.lua.2; cp tl.lua.bak tl.lua; exit 1; }
 	diff tl.lua.1 tl.lua.2
 	busted -v
 

--- a/spec/preload/preload_spec.lua
+++ b/spec/preload/preload_spec.lua
@@ -11,6 +11,7 @@ describe("preload", function()
             end
 
             global love = record
+               draw: function()
                graphics: love_graphics
             end
          ]],
@@ -24,9 +25,9 @@ describe("preload", function()
       local result, err = tl.process("foo.tl", nil, nil, nil, {"love"})
 
       assert.same(nil, err)
-      assert.same(0, #result.syntax_errors)
-      assert.same(0, #result.type_errors)
-      assert.same(0, #result.unknowns)
+      assert.same({}, result.syntax_errors)
+      assert.same({}, result.type_errors)
+      assert.same({}, result.unknowns)
    end)
    it("can require multiple modules", function()
       -- ok
@@ -37,6 +38,7 @@ describe("preload", function()
             end
 
             global love = record
+               draw: function()
                graphics: love_graphics
             end
          ]],
@@ -46,6 +48,7 @@ describe("preload", function()
             end
 
             global hate = record
+               draw: function()
                graphics: hate_graphics
             end
          ]],
@@ -63,9 +66,9 @@ describe("preload", function()
       local result, err = tl.process("foo.tl", nil, nil, nil, {"love", "hate"})
 
       assert.same(nil, err)
-      assert.same(0, #result.syntax_errors)
-      assert.same(0, #result.type_errors)
-      assert.same(0, #result.unknowns)
+      assert.same({}, result.syntax_errors)
+      assert.same({}, result.type_errors)
+      assert.same({}, result.unknowns)
    end)
    it("returns an error when a module doesn't exist", function ()
       -- ok

--- a/spec/require/require_spec.lua
+++ b/spec/require/require_spec.lua
@@ -152,4 +152,35 @@ describe("require", function()
       assert.same(0, #result.unknowns)
    end)
 
+   it("cannot extend a record with unknown types outside of scope", function ()
+      util.mock_io(finally, {
+         ["love.d.tl"] = [[
+            global love_graphics = record
+               print: function(text: string)
+            end
+
+            global love = record
+               draw: function()
+               graphics: love_graphics
+            end
+         ]],
+         ["foo.tl"] = [[
+            function love.draw()
+               love.graphics.print("<3")
+            end
+
+            function love.draws()
+               love.graphics.print("</3")
+            end
+         ]],
+      })
+
+      local result, err = tl.process("foo.tl", nil, nil, nil, {"love"})
+
+      assert.same(nil, err)
+      assert.same({}, result.syntax_errors)
+      assert.match("cannot add undeclared function 'draws' outside of the scope where 'love' was originally declared", result.type_errors[1].msg)
+      assert.same({}, result.unknowns)
+   end)
+
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -3262,8 +3262,9 @@ function tl.type_check(ast, lax, filename, modules, result, globals, skip_compat
             if i == 1 and scope[name].needs_compat53 then
                all_needs_compat53[name] = true
             end
+            local typ = scope[name].t
 
-            return scope[name].t, scope[name].is_const
+            return typ, scope[name].is_const
          end
       end
    end
@@ -4128,6 +4129,32 @@ function tl.type_check(ast, lax, filename, modules, result, globals, skip_compat
       return old
    end
 
+   local function find_in_scope(exp)
+      if exp.kind == "variable" then
+         local name = exp.tk
+         local parent_scope = st[#st - 1]
+         local type_in_scope = parent_scope[name] and parent_scope[name].t
+         if type_in_scope and type_in_scope.typename == "typetype" then
+            type_in_scope = type_in_scope.def
+         end
+         return type_in_scope
+      elseif exp.kind == "op" and exp.op.op == "." then
+         local t = find_in_scope(exp.e1)
+         if not t then
+            return nil
+         end
+         while exp.e2.kind == "op" and exp.e2.op.op == "." do
+            t = t.fields[exp.e2.e1.tk]
+            if not t then
+               return nil
+            end
+            exp = exp.e2
+         end
+         t = t.fields[exp.e2.tk]
+         return t
+      end
+   end
+
    local visit_node = {}
 
    visit_node.cbs = {
@@ -4441,15 +4468,31 @@ function tl.type_check(ast, lax, filename, modules, result, globals, skip_compat
                rtype.typename = "record"
             end
             if (rtype.typename == "record" or rtype.typename == "arrayrecord") then
-               rtype.fields = rtype.fields or {}
-               rtype.field_order = rtype.field_order or {}
-               rtype.fields[node.name.tk] = {
+               local fn_type = {
                   ["typename"] = "function",
                   ["is_method"] = node.is_method,
                   ["args"] = children[3],
                   ["rets"] = get_rets(children[4]),
                }
-               table.insert(rtype.field_order, node.name.tk)
+
+               local ok = false
+               if lax then
+                  ok = true
+               elseif rtype.fields and rtype.fields[node.name.tk] and is_a(fn_type, rtype.fields[node.name.tk]) then
+                  ok = true
+               elseif find_in_scope(node.fn_owner) == rtype then
+                  ok = true
+               end
+
+               if ok then
+                  rtype.fields = rtype.fields or {}
+                  rtype.field_order = rtype.field_order or {}
+                  rtype.fields[node.name.tk] = fn_type
+                  table.insert(rtype.field_order, node.name.tk)
+               else
+                  local name = tl.pretty_print_ast(node.fn_owner)
+                  node_error(node, "cannot add undeclared function '" .. node.name.tk .. "' outside of the scope where '" .. name .. "' was originally declared")
+               end
             else
                node_error(node, "not a module: %s", rtype)
             end

--- a/tl.tl
+++ b/tl.tl
@@ -3262,8 +3262,9 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
             if i == 1 and scope[name].needs_compat53 then
                all_needs_compat53[name] = true
             end
+            local typ = scope[name].t
 
-            return scope[name].t, scope[name].is_const
+            return typ, scope[name].is_const
          end
       end
    end
@@ -4128,6 +4129,32 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
       return old
    end
 
+   local function find_in_scope(exp: Node): Type
+      if exp.kind == "variable" then
+         local name = exp.tk
+         local parent_scope = st[#st - 1]
+         local type_in_scope = parent_scope[name] and parent_scope[name].t
+         if type_in_scope and type_in_scope.typename == "typetype" then
+            type_in_scope = type_in_scope.def
+         end
+         return type_in_scope
+      elseif exp.kind == "op" and exp.op.op == "." then
+         local t = find_in_scope(exp.e1)
+         if not t then
+            return nil
+         end
+         while exp.e2.kind == "op" and exp.e2.op.op == "." do
+            t = t.fields[exp.e2.e1.tk]
+            if not t then
+               return nil
+            end
+            exp = exp.e2
+         end
+         t = t.fields[exp.e2.tk]
+         return t
+      end
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -4441,15 +4468,31 @@ function tl.type_check(ast: Node, lax: boolean, filename: string, modules: {stri
                rtype.typename = "record"
             end
             if (rtype.typename == "record" or rtype.typename == "arrayrecord") then
-               rtype.fields = rtype.fields or {}
-               rtype.field_order = rtype.field_order or {}
-               rtype.fields[node.name.tk] = {
+               local fn_type = {
                   typename = "function",
                   is_method = node.is_method,
                   args = children[3],
                   rets = get_rets(children[4]),
                }
-               table.insert(rtype.field_order, node.name.tk)
+
+               local ok = false
+               if lax then
+                  ok = true
+               elseif rtype.fields and rtype.fields[node.name.tk] and is_a(fn_type, rtype.fields[node.name.tk]) then
+                  ok = true
+               elseif find_in_scope(node.fn_owner) == rtype then
+                  ok = true
+               end
+
+               if ok then
+                  rtype.fields = rtype.fields or {}
+                  rtype.field_order = rtype.field_order or {}
+                  rtype.fields[node.name.tk] = fn_type
+                  table.insert(rtype.field_order, node.name.tk)
+               else
+                  local name = tl.pretty_print_ast(node.fn_owner)
+                  node_error(node, "cannot add undeclared function '" .. node.name.tk .. "' outside of the scope where '" .. name .. "' was originally declared")
+               end
             else
                node_error(node, "not a module: %s", rtype)
             end


### PR DESCRIPTION
tl supports the common pattern of adding functions to an empty table without having to declare them beforehand, which is used in module declarations:

```
local foo = {}

function foo.fun()
end
```

A side effect to this was #39, where arbitrary functions could be created by callers of a module, when making a typo while trying to redefine a function (e.g. for a callback, like `love.draw`).

This restricts the definition of undeclared functions to the same scope level where a record is declared only. So the above example works, but trying to create new functions from other files don't. to declare functions from other files, you have to declare a record type and declare the function as a field to that record, like this:

```
-- love.d.tl
global love = record
   draw: function()
end
```

```
-- main.tl
function love.draw() -- this works
end

function love.bla() -- this doesn't
end
```

Restricting it by scope might be overly restrictive (a simple wrapper `do` block will cause a function to be in a different scope and be rejected) and an alternative to consider could be to do it by file, but there's always the alternative of forward-declaring functions first (like `tl` itself does for `tl.process` and `tl.type_check` for example in lines 2 and 3), so this limitation shouldn't be a show-stopper. So I think this behavior should be fine for now.

Fixes #39.
