### PR TITLE
union types, take 1

### DIFF
--- a/spec/assignment/to_union_spec.lua
+++ b/spec/assignment/to_union_spec.lua
@@ -1,0 +1,64 @@
+local util = require("spec.util")
+
+describe("assignment to union", function()
+   it("accepts either type", util.check [[
+      local t: number | string
+      t = 12
+      t = "hello"
+   ]])
+
+   it("accepts valid but rejects invalid types", util.check_type_error([[
+      local t: number | string | boolean | function(number | string, {string | boolean}):{number | string:string | boolean}
+      t = 12
+      t = "hello"
+      t = true
+      t = function(n: number | string, a: {string | boolean}):{number | string:string | boolean}
+         n = 12
+         n = "hello"
+         a[1] = "hello"
+         a[2] = true
+         return {}
+      end
+      t = { false, false, false } -- will fail!
+      t = function() -- will also fail
+      end
+   ]], {
+      { y = 12, msg = 'in assignment: got {boolean}, expected ' },
+      { y = 13, msg = 'in assignment: got function(), expected ' },
+   }))
+
+   it("accepts narrower types", util.check [[
+      local t: number | string | boolean
+      local u: number | string
+      u = 12
+      t = u
+   ]])
+
+   it("rejects wider types", util.check_type_error([[
+      local t: number | string | boolean
+      local u: number | string
+      t = 12
+      if math.random(10) > 5 then
+         t = "hello"
+      end
+      u = t
+   ]], {
+      { y = 7, msg = 'in assignment: got number | string | boolean, expected number | string' },
+   }))
+
+   pending("resolves union types in map keys", util.check [[
+      function foo(n: number | string, a: {string | boolean}):{number | string:string | boolean}
+         n = 12
+         n = "hello"
+         a[1] = "hello"
+         a[2] = true
+         return {
+            [12] = "hello",
+            [13] = false,
+            ["hello"] = "world",
+            ["world"] = true,
+         }
+      end
+   ]])
+
+end)

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -48,7 +48,7 @@ describe("generic function", function()
             return a
          end
 
-         local function use_id(v: `T, id: Id<`T>): `T
+         local function use_id<`T>(v: `T, id: Id<`T>): `T
             return id(v)
          end
 

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -450,5 +450,19 @@ describe("generic function", function()
       assert.same(11, errors[1].y, 1, true)
       assert.same(42, errors[1].x, 1, true)
    end)
+   it("does not produce a recursive type", util.lax_check([[
+      function mypairs(map: {`a:`b}): (`a, `b)
+      end
+      function myipairs(array: {`a}): (`a)
+      end
+
+      local _, xs = mypairs(xss)
+      local _, x = mypairs(xs)
+      local u = myipairs({})
+      local v = x[u]
+      _, v = next(v)
+   ]], {
+      { msg = "xss" }
+   }))
 end)
 

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -16,7 +16,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local ParseItem = functiontype<`T>(number): `T
 
-         local function parse_list(list: {`T}, parse_item: ParseItem): number, `T
+         local function parse_list<`T>(list: {`T}, parse_item: ParseItem): number, `T
             return 0, list[1]
          end
       ]])
@@ -29,7 +29,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local ParseItem = functiontype<`T>(number): `T
 
-         local function parse_list(list: {`T}, parse_item: ParseItem): number, {`T}
+         local function parse_list<`T>(list: {`T}, parse_item: ParseItem): number, {`T}
             local ret: {`T} = {}
             local n = 0
             return n, ret
@@ -63,7 +63,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local Convert = functiontype<`a, `b>(`a): `b
 
-         local function id(x: `a): `a
+         local function id<`a>(x: `a): `a
             return x
          end
 
@@ -71,7 +71,7 @@ describe("generic function", function()
             return tostring(n)
          end
 
-         local function use_conv(x: `X, cvt: Convert<`X, `Y>): `Y
+         local function use_conv<`X, `Y>(x: `X, cvt: Convert<`X, `Y>): `Y
             return id(cvt(x))
          end
 
@@ -96,7 +96,7 @@ describe("generic function", function()
             return tonumber(s)
          end
 
-         local function use_conv(x: `X, cvt: Convert<`X, `Y>, tvc: Convert<`X, `Y>): `Y -- tvc is not flipped!
+         local function use_conv<`X,`Y>(x: `X, cvt: Convert<`X, `Y>, tvc: Convert<`X, `Y>): `Y -- tvc is not flipped!
             return cvt(tvc(cvt(x)))
          end
 
@@ -126,7 +126,7 @@ describe("generic function", function()
             return a
          end
 
-         local function use_id(v: `T, id: Id<`T>): `T
+         local function use_id<`T>(v: `T, id: Id<`T>): `T
             return id(v)
          end
 
@@ -147,7 +147,7 @@ describe("generic function", function()
             return a
          end
 
-         local function use_id(v: {`T}, id: Id<`T>): `T
+         local function use_id<`T>(v: {`T}, id: Id<`T>): `T
             return id(v[1])
          end
 
@@ -166,7 +166,7 @@ describe("generic function", function()
             return a
          end
 
-         local function use_id(v: {`T}, id: Id<`T>): `T
+         local function use_id<`T>(v: {`T}, id: Id<`T>): `T
             return id(v[1])
          end
 
@@ -184,7 +184,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local ParseItem = functiontype<`X>(number): `X
 
-         local function parse_list(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
+         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
             local ret: {`T} = {}
             local n = 0
             for i, t in ipairs(list) do
@@ -213,7 +213,7 @@ describe("generic function", function()
    it("can use a typevar from an argument as the function return type", function()
       -- ok
       local tokens = tl.lex([[
-         local function parse_list(list: {`T}): `T
+         local function parse_list<`T>(list: {`T}): `T
             return list[1]
          end
       ]])
@@ -224,7 +224,7 @@ describe("generic function", function()
    it("will catch if return value does not match the typevar", function()
       -- fail
       local tokens = tl.lex([[
-         local function parse_list(list: {`T}): `T
+         local function parse_list<`T>(list: {`T}): `T
             return true
          end
       ]])
@@ -241,7 +241,7 @@ describe("generic function", function()
             x: number
          end
 
-         local function insert(list: {`a}, item: `a)
+         local function insert<`a>(list: {`a}, item: `a)
             table.insert(list, item)
          end
 
@@ -259,7 +259,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local ParseItem = functiontype<`V>(number): `V
 
-         local function parse_list(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
+         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
             local ret: {`T} = {}
             local n = 0
             for i, t in ipairs(list) do
@@ -295,7 +295,7 @@ describe("generic function", function()
       local tokens = tl.lex([[
          local ParseItem = functiontype<`V>(number): `V
 
-         local function parse_list(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
+         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
             local ret: {`T} = {}
             local n = 0
             for i, t in ipairs(list) do
@@ -328,7 +328,7 @@ describe("generic function", function()
       local VisitorCallbacks = record<`X, `Y>
       end
 
-      local function recurse_node(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+      local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
       end
 
       local function pretty_print_ast(ast: Node): string
@@ -337,7 +337,7 @@ describe("generic function", function()
          return recurse_node(ast, visit_node, visit_type)
       end
    ]], {
-      { msg = "unknown type Type", x = 132 },
+      { msg = "unknown type Type", x = 136 },
       { msg = "unknown type Type", x = 53 }
    }))
    it("propagates resolved typevar in return type", function()
@@ -351,7 +351,7 @@ describe("generic function", function()
          local VisitorCallbacks = record<`N, `X>
          end
 
-         local function recurse_node(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -376,7 +376,7 @@ describe("generic function", function()
          local VisitorCallbacks = record<`X, `Y>
          end
 
-         local function recurse_node(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -399,7 +399,7 @@ describe("generic function", function()
          local VisitorCallbacks = record<`X, `Y>
          end
 
-         local function recurse_node(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>})
+         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>})
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -450,10 +450,28 @@ describe("generic function", function()
       assert.same(11, errors[1].y, 1, true)
       assert.same(42, errors[1].x, 1, true)
    end)
-   it("does not produce a recursive type", util.lax_check([[
-      function mypairs(map: {`a:`b}): (`a, `b)
+   pending("does not leak an unresolved generic type", function()
+      local tokens = tl.lex([[
+         function mypairs<`a, `b>(map: {`a:`b}): (`a, `b)
+         end
+
+         local _, resolved   = mypairs({["hello"] = true})
+         local _, unresolved = mypairs({})
+      ]])
+      local _, ast = tl.parse_program(tokens, { lax = true })
+      local errors = tl.type_check(ast)
+      assert.same(0, #errors)
+      -- resolved
+      assert.same("string",  ast[2].exps[1].type[1].typename)
+      assert.same("boolean", ast[2].exps[1].type[2].typename)
+      -- unresolved
+      assert.same("unknown", ast[3].exps[1].type[1].typename)
+      assert.same("unknown", ast[3].exps[1].type[2].typename)
+   end)
+   pending("does not produce a recursive type", util.lax_check([[
+      function mypairs<`a, `b>(map: {`a:`b}): (`a, `b)
       end
-      function myipairs(array: {`a}): (`a)
+      function myipairs<`a>(array: {`a}): (`a)
       end
 
       local _, xs = mypairs(xss)

--- a/spec/cast/is_spec.lua
+++ b/spec/cast/is_spec.lua
@@ -1,6 +1,26 @@
 local util = require("spec.util")
 
 describe("flow analysis with is", function()
+   describe("on expressions", function()
+      it("narrows type on expressions with and", util.check [[
+         local x: number | string
+
+         local s = x is string and x:lower()
+      ]])
+
+      it("narrows type on expressions with or", util.check [[
+         local x: number | string
+
+         local s = x is number and tostring(x + 1) or x:lower()
+      ]])
+
+      it("narrows type on expressions with not", util.check [[
+         local x: number | string
+
+         local s = not x is string and tostring(x + 1) or x:lower()
+      ]])
+   end)
+
    describe("on if", function()
       it("resolves both then and else branches", util.check [[
          local t: number | string

--- a/spec/cast/is_spec.lua
+++ b/spec/cast/is_spec.lua
@@ -1,0 +1,162 @@
+local util = require("spec.util")
+
+describe("flow analysis with is", function()
+   describe("on if", function()
+      it("resolves both then and else branches", util.check [[
+         local t: number | string
+         if t is number then
+            print(t + 1)
+         else
+            print(t:upper())
+         end
+      ]])
+
+      it("negates with not", util.check [[
+         local t: number | string
+         if not t is number then
+            print(t:upper())
+         else
+            print(t + 1)
+         end
+      ]])
+
+      it("resolves with elseif", util.check [[
+         local v: number | string | {boolean}
+         if v is number then
+            v = v + 1
+         elseif v is string then
+            print(v:upper())
+         end
+      ]])
+
+      it("resolves incrementally with elseif", util.check [[
+         local v: number | string | {boolean}
+         if v is number then
+            v = v + 1
+         elseif v is string then
+            print(v:upper())
+         else
+            local b: {boolean} = v
+         end
+      ]])
+
+      it("resolves partially", util.check [[
+         local v: number | string | {boolean}
+         if v is number then
+            print(v + 1)
+         else
+            -- v is string | {boolean}
+            v = "hello"
+            v = {true, false}
+         end
+      ]])
+
+      it("builds union types with is and or", util.check [[
+         local v: number | string | {boolean}
+         if (v is number) or (v is string) then
+            v = 2
+            v = "hello"
+         else
+            -- v is {boolean}
+            v = {true, false}
+         end
+      ]])
+
+      it("builds union types with is and or (parses priorities correctly)", util.check [[
+         local v: number | string | {boolean}
+         if v is number or v is string then
+            v = 2
+            v = "hello"
+         else
+            -- v is {boolean}
+            v = {true, false}
+         end
+      ]])
+
+      it("resolves incrementally with elseif and negation", util.check [[
+         local v: number | string | {boolean}
+         if v is number then
+            print(v + 1)
+         elseif not v is {boolean} then
+            print(v:upper())
+         else
+            v = {true, false}
+         end
+      ]])
+
+      it("rejects other side of the union in the tested branch", util.check_type_error([[
+         local t: number | string
+         if t is number then
+            print(t:upper())
+         else
+            print(t + 1)
+         end
+      ]], {
+         { y = 3, msg = 'cannot index something that is not a record: number (inferred at foo.tl:2:13: )' },
+         { y = 5, msg = [[cannot use operator '+' for types string (inferred at foo.tl:4:10: ) and number]] },
+      }))
+
+      it("detects empty unions", util.check_type_error([[
+         local t: number | string
+         if t is number then
+            t = t + 1
+         elseif t is string then
+            print(t:upper())
+         else
+            print(t)
+         end
+      ]], {
+         { y = 6, msg = 'branch is always false' },
+      }))
+   end)
+
+   describe("on while", function()
+      pending("needs to resolve a fixpoint to accept some valid code", util.check [[
+         local t: number | string
+         t = 1
+         if t is number then
+            while t < 1000 do
+               t = t + 1
+               if t == 10 then
+                  t = "hello"
+               end
+               if t is string then
+                  t = 20
+               end
+            end
+         end
+      ]])
+
+      it("needs to resolve a fixpoint to detect some errors", util.check_type_error([[
+         local t: number | string
+         t = 1
+         if t is number then
+            while t < 1000 do -- FIXME: this is accepted even though t is not always a number
+               if t is number then
+                  t = t + 1
+               end
+               if t == 10 then
+                  t = "hello"
+               end
+            end
+         end
+         end
+      ]], {
+         { y = 4, msg = [[cannot use operator '<' for types number | string and number]] },
+      }))
+
+      it("resolves is on the test", util.check [[
+         function process(ts: {number | string})
+            local t: number | string
+            t = ts[1]
+            local i = 1
+            while t is number do
+               print(t + 1)
+               i = i + 1
+               t = ts[i]
+            end
+         end
+      ]])
+   end)
+
+end)

--- a/spec/cast/is_spec.lua
+++ b/spec/cast/is_spec.lua
@@ -211,6 +211,15 @@ describe("flow analysis with is", function()
          ]], {
             { y = 5, msg = [[cannot discriminate a union between multiple string/enum types: string | Enum]] },
          }))
+
+         it("does not produce new unions", util.check_type_error([[
+            local x: number | string
+
+            local s = x is string and x .. "!" or x + 1
+         ]], {
+            { y = 3, msg = [[cannot use operator 'or' for types string and number]] },
+         }))
+
       end)
 
       it("generates type checks for primitive types", util.gen([[

--- a/spec/cli/check_spec.lua
+++ b/spec/cli/check_spec.lua
@@ -31,6 +31,30 @@ describe("tl check", function()
          assert.match("2 errors:", output, 1, true)
       end)
 
+      it("reports errors in multiple files", function()
+         local name1 = util.write_tmp_file(finally, "add.tl", [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]])
+         local name2 = util.write_tmp_file(finally, "foo.tl", [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]])
+         local pd = io.popen("./tl check " .. name1 .. " " .. name2 .. " 2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("add.tl:", output, 1, true)
+         assert.match("foo.tl:", output, 1, true)
+      end)
+
       it("reports number of errors in stderr and code 1 on syntax errors", function()
          local name = util.write_tmp_file(finally, "add.tl", [[
             print(add("string", 20))))))

--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -16,6 +16,20 @@ describe("local function", function()
          assert.same({}, errors)
       end)
 
+      it("can have type variables", function()
+         local tokens = tl.lex([[
+            local f: function<`a, `b, `c>(`a, `b): `c
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
       it("can take names in arguments but names are ignored", function()
          local tokens = tl.lex([[
             local f: function(x: number, y: string): boolean
@@ -65,6 +79,22 @@ describe("local function", function()
             return #b == a
          end
          local ok = f(3, "abc")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same({}, errors)
+   end)
+
+   it("declaration with type variables", function()
+      local tokens = tl.lex([[
+         local function f<`a, `b>(a1: `a, a2: `a, b1: `b, b2: `b): `b
+            if a1 == a2 then
+               return b1
+            else
+               return b2
+            end
+         end
+         local ok = f(10, 20, "hello", "world")
       ]])
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
@@ -144,7 +174,7 @@ describe("local function", function()
 
       it("has no ambiguity with parentheses in function type return", function()
          local tokens = tl.lex([[
-            local function map(f: function(`a):(`b), xs: {`a}): {`b}
+            local function map<`a,`b>(f: function(`a):(`b), xs: {`a}): {`b}
                local r = {}
                for i, x in ipairs(xs) do
                   r[i] = f(x)

--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -22,6 +22,27 @@ describe("record method", function()
       assert.same({}, errors)
    end)
 
+   it("valid declaration with type variables", function()
+      local tokens = tl.lex([[
+         local r = {
+            x = 2,
+            b = true,
+         }
+         function r:f<`T>(a: number, b: string, xs: {`T}): boolean, `T
+            if self.b then
+               return #b == 3, xs[1]
+            else
+               return a > self.x, xs[2]
+            end
+         end
+         local ok, s = r:f(3, "abc", {"what"})
+         print(s .. "!")
+      ]])
+      local _, ast = tl.parse_program(tokens)
+      local errors = tl.type_check(ast)
+      assert.same({}, errors)
+   end)
+
    it("nested declaration", function()
       local tokens = tl.lex([[
          local r = {

--- a/spec/declaration/union_spec.lua
+++ b/spec/declaration/union_spec.lua
@@ -1,0 +1,11 @@
+local util = require("spec.util")
+
+describe("union declaration", function()
+   it("declares a union", util.check [[
+      local t: number | string
+   ]])
+
+   it("declares a long union", util.check [[
+      local t: number | string | boolean | function(number | string, {string | boolean}):{number | string:string | boolean}
+   ]])
+end)

--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -22,6 +22,17 @@ describe("forin", function()
             end
          end
       ]])
+      it("unknown with nested ipairs", util.lax_check([[
+         local t = {}
+         for i, a in ipairs(t) do
+            for j, b in ipairs(a) do
+               print(i, j, "value: " .. b)
+            end
+         end
+      ]], {
+         { msg = "a" },
+         { msg = "b" },
+      }))
       it("rejects nested unknown ipairs", util.check_type_error([[
          local t = {}
          for i, a in ipairs(t) do

--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -1,4 +1,5 @@
 local tl = require("tl")
+local util = require("spec.util")
 
 describe("forin", function()
    it("with a single variable", function()
@@ -35,5 +36,27 @@ describe("forin", function()
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
       assert.same({}, errors)
+   end)
+   describe("regressions", function()
+      it("accepts nested unresolved values", util.lax_check([[
+         function fun(xss)
+           for _, xs in pairs(xss) do
+             for _, x in pairs(xs) do
+               for _, u in ipairs({}) do
+                local v = x[u]
+                _, v = next(v)
+               end
+             end
+           end
+         end
+      ]], {
+         { msg = "xss" },
+         { msg = "_" },
+         { msg = "xs" },
+         { msg = "_" },
+         { msg = "x" },
+         { msg = "u" },
+         { msg = "v" },
+      }))
    end)
 end)

--- a/spec/statement/goto_spec.lua
+++ b/spec/statement/goto_spec.lua
@@ -1,0 +1,91 @@
+local util = require("spec.util")
+
+describe("goto", function()
+
+   it("parses", util.check [[
+      local b = true
+      if b then
+         print(b)
+         goto my_label
+      end
+      ::my_label::
+      print(b)
+   ]])
+
+   it("rejects an invalid label", util.check_syntax_error([[
+      goto 123
+      ::123:: print("no line numbers :(")
+   ]], {
+      { y = 1 },
+      { y = 2 },
+   }))
+
+   it("rejects a repeated label", util.check_type_error([[
+      ::my_label::
+      do
+         ::my_label::
+      end
+      ::my_label::
+   ]], {
+      { y = 5, msg = "label 'my_label' already defined" }
+   }))
+
+   it("accepts a label in a different scope", util.check [[
+      ::my_label::
+      do
+         ::my_label::
+         do
+            ::my_label::
+         end
+      end
+   ]])
+
+   it("accepts a label in a different scope", util.check [[
+      do
+         ::my_label::
+      end
+      ::my_label::
+   ]])
+
+   it("accepts a label outside above", util.check [[
+      ::my_label::
+      do
+         goto my_label
+      end
+   ]])
+
+   it("accepts a label outside below", util.check [[
+      do
+         goto my_label
+      end
+      ::my_label::
+   ]])
+
+   it("accepts a label in the same scope above", util.check [[
+      ::my_label::
+      goto my_label
+   ]])
+
+   it("accepts a label in the same scope below", util.check [[
+      goto my_label
+      ::my_label::
+   ]])
+
+   it("rejects a label inside above", util.check_type_error([[
+      do
+         ::my_label::
+      end
+      goto my_label
+   ]], {
+      { y = 4, msg = "no visible label 'my_label'" }
+   }))
+
+   it("rejects a label inside below", util.check_type_error([[
+      goto my_label
+      do
+         ::my_label::
+      end
+   ]], {
+      { y = 1, msg = "no visible label 'my_label'" }
+   }))
+end)

--- a/spec/stdlib/string_spec.lua
+++ b/spec/stdlib/string_spec.lua
@@ -17,8 +17,8 @@ describe("string", function()
 
    describe("match", function()
       it("can take an optional init position", util.check [[
-         local s1: string = string.match("hello world", "world"))
-         local s2: string = string.match("hello world", "world", 2))
+         local s1: string = string.match("hello world", "world")
+         local s2: string = string.match("hello world", "world", 2)
       ]])
    end)
 

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -93,7 +93,9 @@ end
 local function check(lax, code, unknowns)
    return function()
       local tokens = tl.lex(code)
-      local _, ast = tl.parse_program(tokens)
+      local syntax_errors = {}
+      local _, ast = tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors, "Code was not expected to have syntax errors")
       local errors, unks = tl.type_check(ast, { filename = "foo.tl", lax = lax })
       assert.same({}, errors)
       if unknowns then

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -185,4 +185,29 @@ function util.check_syntax_error(code, syntax_errors)
    end
 end
 
+local function gen(lax, code, expected)
+   return function()
+      local tokens = tl.lex(code)
+      local syntax_errors = {}
+      local _, ast = tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors, "Code was not expected to have syntax errors")
+      local errors, unks = tl.type_check(ast, { filename = "foo.tl", lax = lax })
+      assert.same({}, errors)
+      local output_code = tl.pretty_print_ast(ast)
+
+      local expected_tokens = tl.lex(expected)
+      local _, expected_ast = tl.parse_program(expected_tokens, {})
+      local expected_code = tl.pretty_print_ast(expected_ast)
+
+      assert.same(expected_code, output_code)
+   end
+end
+
+function util.gen(code, expected)
+   assert(type(code) == "string")
+   assert(type(expected) == "string")
+
+   return gen(false, code, expected)
+end
+
 return util

--- a/tl
+++ b/tl
@@ -128,13 +128,13 @@ local function report_errors(category, errors)
    return false
 end
 
+local exit = 0
+
 local function report_type_errors(result)
    local has_type_errors = report_errors("error", result.type_errors)
    report_errors("unknown variable", result.unknowns)
 
-   if has_type_errors then
-      os.exit(1)
-   end
+   return not has_type_errors
 end
 
 for _, filename in ipairs(args["script"]) do
@@ -145,14 +145,19 @@ for _, filename in ipairs(args["script"]) do
 
    local has_syntax_errors = report_errors("syntax error", result.syntax_errors)
    if has_syntax_errors then
-      os.exit(1)
+      exit = 1
+      break
    end
 
    local lua_name = filename:gsub(".tl$", ".lua")
 
    if cmd == "run" then
       if filename:match("%.tl$") then
-         report_type_errors(result)
+         local ok = report_type_errors(result)
+         if not ok then
+            exit = 1
+            break
+         end
       end
 
       local chunk = (loadstring or load)(tl.pretty_print_ast(result.ast), "@" .. filename)
@@ -163,11 +168,13 @@ for _, filename in ipairs(args["script"]) do
       end
       arg[narg] = nil
       arg[narg - 1] = nil
-
       return chunk()
 
    elseif cmd == "check" then
-      report_type_errors(result)
+      local ok = report_type_errors(result)
+      if not ok then
+         exit = 1
+      end
 
       if #args["script"] == 1 then
          print("========================================")
@@ -199,3 +206,5 @@ for _, filename in ipairs(args["script"]) do
 
    end
 end
+
+os.exit(exit)

--- a/tl.lua
+++ b/tl.lua
@@ -4986,10 +4986,8 @@ function tl.type_check(ast, opts)
             local exp1 = node.exps[1]
             local exp1type = resolve_tuple(exp1.type)
             if exp1type.typename == "function" then
-               add_var(node.vars[1], node.vars[1].tk, exp1type.rets[1])
-               if node.vars[2] then
-                  add_var(node.vars[2], node.vars[2].tk, exp1type.rets[2])
-               end
+               local r1 = exp1type.rets[1]
+               local r2 = exp1type.rets[2]
 
                if exp1.op and exp1.op.op == "@funcall" then
                   local t = resolve_unary(exp1.e2.type)
@@ -4997,11 +4995,18 @@ function tl.type_check(ast, opts)
                      if not (lax and is_unknown(t)) then
                         node_error(exp1, "attempting pairs loop on something that's not a map or record: %s", exp1.e2.type)
                      end
+                     r1 = UNKNOWN
+                     r2 = UNKNOWN
                   elseif exp1.e1.tk == "ipairs" and not (t.typename == "array" or t.typename == "arrayrecord") then
                      if not (lax and (is_unknown(t) or t.typename == "emptytable")) then
                         node_error(exp1, "attempting ipairs loop on something that's not an array: %s", exp1.e2.type)
                      end
+                     r2 = UNKNOWN
                   end
+               end
+               add_var(node.vars[1], node.vars[1].tk, r1)
+               if node.vars[2] then
+                  add_var(node.vars[2], node.vars[2].tk, r2)
                end
             else
                if not (lax and is_unknown(exp1type)) then
@@ -5257,6 +5262,9 @@ function tl.type_check(ast, opts)
                   else
                      node_error(node, "rawget expects two arguments")
                   end
+               elseif node.e1.tk == "print_type" then
+                  print(show_type(b))
+                  node.type = BOOLEAN
                elseif node.e1.tk == "require" then
                   if #b == 1 then
                      if node.e2[1].kind == "string" then

--- a/tl.lua
+++ b/tl.lua
@@ -897,6 +897,7 @@ local Node = {}
 
 
 
+
 local parse_expression
 local parse_statements
 local parse_type_list
@@ -1067,29 +1068,8 @@ local function parse_trying_list(tokens, i, errs, list, parse_item)
    return i, list
 end
 
-local function parse_function_type(tokens, i, errs)
-   i = i + 1
-   local node = {
-      ["typeid"] = new_typeid(),
-      ["y"] = tokens[i - 1].y,
-      ["x"] = tokens[i - 1].x,
-      ["kind"] = "typedecl",
-      ["typename"] = "function",
-      ["args"] = {},
-      ["rets"] = {},
-   }
-   if tokens[i].tk == "(" then
-      i, node.args = parse_argument_type_list(tokens, i, errs)
-      i, node.rets = parse_type_list(tokens, i, errs)
-   else
-      node.args = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "any", ["is_va"] = true, }, }
-      node.rets = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "any", ["is_va"] = true, }, }
-   end
-   return i, node
-end
-
 local function parse_typevar_type(tokens, i, errs)
-   i = i + 1
+   i = verify_tk(tokens, i, errs, "`")
    i = verify_kind(tokens, i, errs, "identifier")
    return i, {
       ["typeid"] = new_typeid(),
@@ -1109,6 +1089,29 @@ end
 local function parse_typeval_list(tokens, i, errs)
    local typ = new_type(tokens, i, "typeval_list")
    return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_type)
+end
+
+local function parse_function_type(tokens, i, errs)
+   i = i + 1
+   local node = {
+      ["y"] = tokens[i - 1].y,
+      ["x"] = tokens[i - 1].x,
+      ["kind"] = "typedecl",
+      ["typename"] = "function",
+      ["args"] = {},
+      ["rets"] = {},
+   }
+   if tokens[i].tk == "<" then
+      i, node.typevars = parse_typevar_list(tokens, i, errs)
+   end
+   if tokens[i].tk == "(" then
+      i, node.args = parse_argument_type_list(tokens, i, errs)
+      i, node.rets = parse_type_list(tokens, i, errs)
+   else
+      node.args = { [1] = { ["typename"] = "any", ["is_va"] = true, }, }
+      node.rets = { [1] = { ["typename"] = "any", ["is_va"] = true, }, }
+   end
+   return i, node
 end
 
 local function parse_base_type(tokens, i, errs)
@@ -1220,6 +1223,9 @@ parse_type_list = function(tokens, i, errs, open)
 end
 
 local function parse_function_args_rets_body(tokens, i, errs, node)
+   if tokens[i].tk == "<" then
+      i, node.typevars = parse_typevar_list(tokens, i, errs)
+   end
    i, node.args = parse_argument_list(tokens, i, errs)
    i, node.rets = parse_type_list(tokens, i, errs)
    i, node.body = parse_statements(tokens, i, errs)
@@ -1788,16 +1794,7 @@ parse_newtype = function(tokens, i, errs)
       i = verify_tk(tokens, i, errs, "end")
       return i, node
    elseif tokens[i].tk == "functiontype" then
-      local typevars
-      i = i + 1
-      if tokens[i].tk == "<" then
-         i, typevars = parse_typevar_list(tokens, i, errs)
-      end
-      i = i - 1
       i, node.newtype.def = parse_function_type(tokens, i, errs)
-      if typevars then
-         node.newtype.def.typevars = typevars
-      end
       return i, node
    end
    return fail(tokens, i, errs)
@@ -3075,24 +3072,24 @@ local standard_library = {
    ["any"] = { ["typeid"] = new_typeid(), ["typename"] = "typetype", ["def"] = ANY, },
    ["arg"] = ARRAY_OF_STRING,
    ["require"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = STRING, }, ["rets"] = {}, },
-   ["setmetatable"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ALPHA, [2] = METATABLE, }, ["rets"] = { [1] = ALPHA, }, },
+   ["setmetatable"] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, }, ["typename"] = "function", ["args"] = { [1] = ALPHA, [2] = METATABLE, }, ["rets"] = { [1] = ALPHA, }, },
    ["getmetatable"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ANY, }, ["rets"] = { [1] = METATABLE, }, },
    ["rawget"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = TABLE, [2] = ANY, }, ["rets"] = { [1] = ANY, }, },
    ["rawset"] = {
       ["typeid"] = new_typeid(), ["typename"] = "poly",
       ["poly"] = {
-         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, [2] = ALPHA, [3] = BETA, }, ["rets"] = {}, },
-         [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = ALPHA, }, ["rets"] = {}, },
+         [1] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, [2] = ALPHA, [3] = BETA, }, ["rets"] = {}, },
+         [2] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, }, ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = ALPHA, }, ["rets"] = {}, },
          [3] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = TABLE, [2] = ANY, [3] = ANY, }, ["rets"] = {}, },
       },
    },
    ["next"] = {
       ["typeid"] = new_typeid(), ["typename"] = "poly",
       ["poly"] = {
-         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, }, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
-         [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, [2] = ALPHA, }, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
-         [3] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = NUMBER, [2] = ALPHA, }, },
-         [4] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = ALPHA, }, ["rets"] = { [1] = NUMBER, [2] = ALPHA, }, },
+         [1] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, }, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
+         [2] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["typename"] = "function", ["args"] = { [1] = MAP_OF_ALPHA_TO_BETA, [2] = ALPHA, }, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
+         [3] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, }, ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = NUMBER, [2] = ALPHA, }, },
+         [4] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, }, ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = ALPHA, }, ["rets"] = { [1] = NUMBER, [2] = ALPHA, }, },
       },
    },
    ["load"] = {
@@ -3133,7 +3130,7 @@ local standard_library = {
             ["__call"] = FUNCTION,
             ["__gc"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ANY, }, ["rets"] = {}, },
             ["__len"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ANY, }, ["rets"] = { [1] = NUMBER, }, },
-            ["__pairs"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "map", ["keys"] = ALPHA, ["values"] = BETA, }, }, ["rets"] = {
+            ["__pairs"] = { ["typeid"] = new_typeid(), ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["typename"] = "function", ["args"] = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "map", ["keys"] = ALPHA, ["values"] = BETA, }, }, ["rets"] = {
                   [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = {}, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
                }, },
 
@@ -3196,28 +3193,29 @@ local standard_library = {
          ["unpack"] = {
             ["typeid"] = new_typeid(), ["typename"] = "function",
             ["needs_compat53"] = true,
+            ["typevars"] = { [1] = ALPHA, },
             ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, },
             ["rets"] = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "typevar", ["typevar"] = "`a", ["is_va"] = true, },
             }, },
          ["move"] = {
             ["typeid"] = new_typeid(), ["typename"] = "poly",
             ["poly"] = {
-               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, [4] = NUMBER, }, ["rets"] = { [1] = ARRAY_OF_ALPHA, }, },
-               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, [4] = NUMBER, [5] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = ARRAY_OF_ALPHA, }, },
+               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, [4] = NUMBER, }, ["rets"] = { [1] = ARRAY_OF_ALPHA, }, },
+               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, [4] = NUMBER, [5] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = ARRAY_OF_ALPHA, }, },
             },
          },
          ["insert"] = {
             ["typeid"] = new_typeid(), ["typename"] = "poly",
             ["poly"] = {
-               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = ALPHA, }, ["rets"] = {}, },
-               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = ALPHA, }, ["rets"] = {}, },
+               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = ALPHA, }, ["rets"] = {}, },
+               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = ALPHA, }, ["rets"] = {}, },
             },
          },
          ["remove"] = {
             ["typeid"] = new_typeid(), ["typename"] = "poly",
             ["poly"] = {
-               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, }, ["rets"] = { [1] = ALPHA, }, },
-               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
+               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, }, ["rets"] = { [1] = ALPHA, }, },
+               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
             },
          },
          ["concat"] = {
@@ -3230,8 +3228,8 @@ local standard_library = {
          ["sort"] = {
             ["typeid"] = new_typeid(), ["typename"] = "poly",
             ["poly"] = {
-               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = {}, },
-               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ALPHA, [2] = ALPHA, }, ["rets"] = { [1] = BOOLEAN, }, }, }, ["rets"] = {}, },
+               [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = {}, },
+               [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ALPHA, [2] = ALPHA, }, ["rets"] = { [1] = BOOLEAN, }, }, }, ["rets"] = {}, },
             },
          },
       },
@@ -3296,24 +3294,24 @@ local standard_library = {
          ["offset"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = STRING, [2] = NUMBER, [3] = NUMBER, }, ["rets"] = { [1] = NUMBER, }, },
       },
    },
-   ["ipairs"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = {
+   ["ipairs"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ARRAY_OF_ALPHA, }, ["rets"] = {
          [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = {}, ["rets"] = { [1] = NUMBER, [2] = ALPHA, }, },
       }, },
-   ["pairs"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "map", ["keys"] = ALPHA, ["values"] = BETA, }, }, ["rets"] = {
+   ["pairs"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["args"] = { [1] = { ["typeid"] = new_typeid(), ["typename"] = "map", ["keys"] = ALPHA, ["values"] = BETA, }, }, ["rets"] = {
          [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = {}, ["rets"] = { [1] = ALPHA, [2] = BETA, }, },
       }, },
    ["pcall"] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = VARARG_ANY, }, ["rets"] = { [1] = BOOLEAN, [2] = ANY, }, },
    ["assert"] = {
       ["typeid"] = new_typeid(), ["typename"] = "poly",
       ["poly"] = {
-         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
-         [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = ALPHA, [2] = BETA, }, ["rets"] = { [1] = ALPHA, }, },
+         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
+         [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, [2] = BETA, }, ["args"] = { [1] = ALPHA, [2] = BETA, }, ["rets"] = { [1] = ALPHA, }, },
       },
    },
    ["select"] = {
       ["typeid"] = new_typeid(), ["typename"] = "poly",
       ["poly"] = {
-         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = NUMBER, [2] = ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
+         [1] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["typevars"] = { [1] = ALPHA, }, ["args"] = { [1] = NUMBER, [2] = ALPHA, }, ["rets"] = { [1] = ALPHA, }, },
          [2] = { ["typeid"] = new_typeid(), ["typename"] = "function", ["args"] = { [1] = STRING, [2] = VARARG_ANY, }, ["rets"] = { [1] = NUMBER, }, },
       },
    },
@@ -3524,7 +3522,7 @@ function tl.type_check(ast, opts)
       return t
    end
 
-   local function error_in_type(t, msg, ...)
+   local function error_in_type(where, msg, ...)
       local n = select("#", ...)
       if n > 0 then
          local showt = {}
@@ -3539,8 +3537,8 @@ function tl.type_check(ast, opts)
       end
 
       return {
-         ["y"] = t.y,
-         ["x"] = t.x,
+         ["y"] = where.y,
+         ["x"] = where.x,
          ["msg"] = msg,
          ["filename"] = filename,
       }

--- a/tl.lua
+++ b/tl.lua
@@ -685,7 +685,11 @@ local TypeName = {}
 
 
 
+
 local Type = {}
+
+
+
 
 
 
@@ -800,7 +804,19 @@ local NodeKind = {}
 
 
 
+local FactType = {}
+
+
+
+local Fact = {}
+
+
+
+
+
 local Node = {}
+
+
 
 
 
@@ -1072,7 +1088,7 @@ local function parse_typeval_list(tokens, i, errs)
    return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_type)
 end
 
-parse_type = function(tokens, i, errs)
+local function parse_base_type(tokens, i, errs)
    if tokens[i].tk == "string" or
       tokens[i].tk == "boolean" or
       tokens[i].tk == "nil" or
@@ -1134,6 +1150,31 @@ parse_type = function(tokens, i, errs)
       return i, typ
    end
    return fail(tokens, i, errs)
+end
+
+parse_type = function(tokens, i, errs)
+   local istart = i
+   local bt
+   i, bt = parse_base_type(tokens, i, errs)
+   if not bt then
+      return i
+   end
+   if tokens[i].tk == "|" then
+      local u = new_type(tokens, istart, "typedecl")
+      u.typename = "union"
+      u.types = { [1] = bt, }
+      while tokens[i].tk == "|" do
+         i = i + 1
+         i, bt = parse_base_type(tokens, i, errs)
+         if not bt then
+            return i
+         end
+         table.insert(u.types, bt)
+      end
+      return i, u
+   else
+      return i, bt
+   end
 end
 
 parse_type_list = function(tokens, i, errs, open)
@@ -1220,6 +1261,7 @@ do
          ["~"] = 11,
       },
       [2] = {
+         ["is"] = 0,
          ["or"] = 1,
          ["and"] = 2,
          ["<"] = 3,
@@ -1319,8 +1361,8 @@ do
             i, key = verify_kind(tokens, i, errs, "identifier")
 
             e1 = { ["y"] = t1.y, ["x"] = t1.x, ["kind"] = "op", ["op"] = op, ["e1"] = e1, ["e2"] = key, }
-         elseif tokens[i].tk == "as" then
-            local op = new_operator(tokens[i], 2, "as")
+         elseif tokens[i].tk == "as" or tokens[i].tk == "is" then
+            local op = new_operator(tokens[i], 2, tokens[i].tk)
 
             i = i + 1
             local cast = new_node(tokens, i, "cast")
@@ -2459,6 +2501,12 @@ function tl.pretty_print_ast(ast, fast)
                table.insert(out, "]")
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
+            elseif node.op.op == "is" then
+               table.insert(out, "type(")
+               add_child(out, children[1], "", indent)
+               table.insert(out, ") == \"")
+               add_child(out, children[3], "", indent)
+               table.insert(out, "\"")
             elseif spaced_op[node.op.arity][node.op.op] or tight_op[node.op.arity][node.op.op] then
                local space = spaced_op[node.op.arity][node.op.op] and " " or ""
                if children[2] and node.op.prec > tonumber(children[2]) then
@@ -2774,6 +2822,12 @@ local function show_type_base(t, typevars)
          table.insert(out, show_type(v))
       end
       return table.concat(out, " or ")
+   elseif t.typename == "union" then
+      local out = {}
+      for _, v in ipairs(t.types) do
+         table.insert(out, show_type(v))
+      end
+      return table.concat(out, " | ")
    elseif t.typename == "emptytable" then
       return "{}"
    elseif t.typename == "map" then
@@ -2899,6 +2953,8 @@ function tl.search_module(module_name, search_dtl)
 end
 
 local Variable = {}
+
+
 
 
 
@@ -3612,7 +3668,25 @@ function tl.type_check(ast, opts)
       end
    end
 
-   local function same_type(t1, t2, typevars)
+   local same_type
+
+   local function has_all_types_of(t1s, t2s, typevars)
+      for _, t1 in ipairs(t1s) do
+         local found = false
+         for _, t2 in ipairs(t2s) do
+            if same_type(t1, t2, typevars) then
+               found = true
+               break
+            end
+         end
+         if not found then
+            return false
+         end
+      end
+      return true
+   end
+
+   same_type = function(t1, t2, typevars)
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
@@ -3627,6 +3701,13 @@ function tl.type_check(ast, opts)
          return same_type(t1.elements, t2.elements)
       elseif t1.typename == "map" then
          return same_type(t1.keys, t2.keys) and same_type(t1.values, t2.values)
+      elseif t1.typename == "union" then
+         if has_all_types_of(t1.types, t2.types, typevars) and
+            has_all_types_of(t2.types, t1.types, typevars) then
+            return true
+         else
+            return false, terr(t1, "got %s, expected %s", t1, t2)
+         end
       elseif t1.typename == "nominal" then
          return same_names(t1, t2)
       elseif t1.typename == "record" then
@@ -3718,6 +3799,18 @@ function tl.type_check(ast, opts)
             end
          end
          return false, terr(t1, "no match with poly")
+      elseif t1.typename == "union" and t2.typename == "union" then
+         if has_all_types_of(t1.types, t2.types, typevars) then
+            return true
+         else
+            return false, terr(t1, "got %s, expected %s", t1, t2)
+         end
+      elseif t2.typename == "union" then
+         for _, t in ipairs(t2.types) do
+            if is_a(t1, t, typevars, for_equality) then
+               return true
+            end
+         end
       elseif t1.typename == "poly" then
          for _, t in ipairs(t1.poly) do
             if is_a(t, t2, typevars, for_equality) then
@@ -4083,11 +4176,55 @@ function tl.type_check(ast, opts)
       return node_error(node, "invalid key '" .. key.tk .. "' in " .. description)
    end
 
-   local function add_var(node, var, valtype, is_const)
+   local function add_var(node, var, valtype, is_const, is_narrowing)
       if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
          add_unknown(node, var)
       end
-      st[#st][var] = { ["t"] = valtype, ["is_const"] = is_const, }
+      if st[#st][var] and is_narrowing then
+         if not st[#st][var].is_narrowed then
+            st[#st][var].narrowed_from = st[#st][var].t
+         end
+         st[#st][var].is_narrowed = true
+         st[#st][var].t = valtype
+      else
+         st[#st][var] = { ["t"] = valtype, ["is_const"] = is_const, ["is_narrowed"] = is_narrowing, }
+      end
+   end
+
+   local function widen_in_scope(scope, var)
+      if scope[var].is_narrowed then
+         if scope[var].narrowed_from then
+            scope[var].t = scope[var].narrowed_from
+            scope[var].narrowed_from = nil
+            scope[var].is_narrowed = false
+         else
+            scope[var] = nil
+         end
+         return true
+      end
+      return false
+   end
+
+   local function widen_back_var(var)
+      local widened = false
+      for i = #st, 1, -1 do
+         if st[i][var] then
+            if widen_in_scope(st[i], var) then
+               widened = true
+            else
+               break
+            end
+         end
+      end
+      return widened
+   end
+
+   local function widen_all_unions()
+      for i = #st, 1, -1 do
+         for var, _ in pairs(st[i]) do
+            widen_in_scope(st[i], var)
+         end
+      end
    end
 
    local function add_global(node, var, valtype, is_const)
@@ -4300,6 +4437,218 @@ function tl.type_check(ast, opts)
       end
    end
 
+   local facts_and
+   local facts_or
+   local facts_not
+   do
+      local function join_facts(fss)
+         local vars = {}
+
+         for _, fs in ipairs(fss) do
+            for _, f in ipairs(fs) do
+               if not vars[f.var] then
+                  vars[f.var] = {}
+               end
+               table.insert(vars[f.var], f)
+            end
+         end
+         return vars
+      end
+
+      local function intersect(xs, ys, same)
+         local rs = {}
+         for i = #xs, 1, -1 do
+            local x = xs[i]
+            for _, y in ipairs(ys) do
+               if same(x, y) then
+                  table.insert(rs, x)
+                  break
+               end
+            end
+         end
+         return rs
+      end
+
+      local function same_type_for_intersect(t, u)
+         return (same_type(t, u, nil))
+      end
+
+      local function intersect_facts(fs, errnode)
+         local all_is = true
+         local types = {}
+         for i, f in ipairs(fs) do
+            if f.fact ~= "is" then
+               all_is = false
+               break
+            end
+            if f.typ.typename == "union" then
+               if i == 1 then
+                  types = f.typ.types
+               else
+                  types = intersect(types, f.typ.types, same_type_for_intersect)
+               end
+            else
+               if i == 1 then
+                  types = { [1] = f.typ, }
+               else
+                  types = intersect(types, { [1] = f.typ, }, same_type_for_intersect)
+               end
+            end
+         end
+
+         if #types == 0 then
+            node_error(errnode, "branch is always false")
+            return false
+         end
+
+         if all_is then
+            if #types == 1 then
+               return true, types[1]
+            else
+               return true, {
+                  ["typeid"] = new_typeid(),
+                  ["typename"] = "union",
+                  ["types"] = types,
+               }
+            end
+         else
+            return false
+         end
+      end
+
+      local function sum_facts(fs)
+         local all_is = true
+         local types = {}
+         for _, f in ipairs(fs) do
+            if f.fact ~= "is" then
+               all_is = false
+               break
+            end
+            table.insert(types, f.typ)
+         end
+
+         if all_is then
+            if #types == 1 then
+               return true, types[1]
+            else
+               return true, {
+                  ["typeid"] = new_typeid(),
+                  ["typename"] = "union",
+                  ["types"] = types,
+               }
+            end
+         else
+            return false
+         end
+      end
+
+      local function subtract_types(u1, u2, errt)
+         local types = {}
+         for _, rt in ipairs(u1.types or { [1] = u1, }) do
+            local not_present = true
+            for _, ft in ipairs(u2.types or { [1] = u2, }) do
+               if same_type(rt, ft) then
+                  not_present = false
+                  break
+               end
+            end
+            if not_present then
+               table.insert(types, rt)
+            end
+         end
+
+         if #types == 0 then
+            type_error(errt, "branch is always false")
+            return INVALID
+         end
+
+         if #types == 1 then
+            return types[1]
+         else
+            return {
+               ["typeid"] = new_typeid(),
+               ["typename"] = "union",
+               ["types"] = types,
+            }
+         end
+      end
+
+      facts_and = function(f1, f2, errnode)
+         if not f1 then
+            return f2
+         end
+         if not f2 then
+            return f1
+         end
+
+         local out = {}
+         for v, fs in pairs(join_facts({ [1] = f1, [2] = f2, })) do
+            local ok, u = intersect_facts(fs, errnode)
+
+            if ok then
+               table.insert(out, { ["fact"] = "is", ["var"] = v, ["typ"] = u, })
+            else
+
+               for _, f in ipairs(fs) do
+                  table.insert(out, f)
+               end
+            end
+         end
+         return out
+      end
+
+      facts_or = function(f1, f2)
+         if not f1 or not f2 then
+            return nil
+         end
+
+         local out = {}
+         for v, fs in pairs(join_facts({ [1] = f1, [2] = f2, })) do
+            local ok, u = sum_facts(fs)
+            if ok then
+               table.insert(out, { ["fact"] = "is", ["var"] = v, ["typ"] = u, })
+            else
+
+               for _, f in ipairs(fs) do
+                  table.insert(out, f)
+               end
+            end
+         end
+         return out
+      end
+
+      facts_not = function(f1)
+         if not f1 then
+            return nil
+         end
+
+         local out = {}
+         for v, fs in pairs(join_facts({ [1] = f1, })) do
+            local realtype = find_var(v)
+            local ok, u = sum_facts(fs)
+            if ok then
+               local not_typ = subtract_types(realtype, u, fs[1].typ)
+               table.insert(out, { ["fact"] = "is", ["var"] = v, ["typ"] = not_typ, })
+            end
+         end
+         return out
+      end
+   end
+
+   local function apply_facts(where, facts)
+      if not facts then
+         return
+      end
+      for _, f in ipairs(facts) do
+         if f.fact == "is" then
+            local t = resolve_typevars(f.typ, {})
+            t.inferred_at = where
+            t.inferred_at_file = filename
+            add_var(nil, f.var, t, nil, true)
+         end
+      end
+   end
+
    local visit_node = {}
 
    visit_node.cbs = {
@@ -4339,6 +4688,7 @@ function tl.type_check(ast, opts)
                   t.declared_at = node
                   t.assigned_to = var.tk
                end
+               assert(var)
                add_var(var, var.tk, t, var.is_const)
             end
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
@@ -4393,10 +4743,19 @@ function tl.type_check(ast, opts)
                if varnode.is_const then
                   node_error(varnode, "cannot assign to <const> variable")
                end
+               if varnode.kind == "variable" then
+                  if widen_back_var(varnode.tk) then
+                     vartype = find_var(varnode.tk)
+                  end
+               end
                if vartype then
                   local val = exps[i]
                   if val then
                      assert_is_a(varnode, val, vartype, {}, "assignment")
+                     if varnode.kind == "variable" and vartype.typename == "union" then
+
+                        add_var(varnode, varnode.tk, val, false, true)
+                     end
                   else
                      node_error(varnode, "variable is not being assigned a value")
                   end
@@ -4407,7 +4766,71 @@ function tl.type_check(ast, opts)
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
       },
+      ["do"] = {
+         ["after"] = function(node, children)
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
       ["if"] = {
+         ["before_statements"] = function(node)
+            table.insert(st, {})
+            apply_facts(node.exp, node.exp.facts)
+         end,
+         ["after"] = function(node, children)
+            table.remove(st)
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
+      ["elseif"] = {
+         ["before"] = function(node)
+            table.remove(st)
+            table.insert(st, {})
+         end,
+         ["before_statements"] = function(node)
+            local f = facts_not(node.parent_if.exp.facts)
+            for e = 1, node.elseif_n - 1 do
+               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.facts), node)
+            end
+            f = facts_and(f, node.exp.facts, node)
+            apply_facts(node.exp, f)
+         end,
+         ["after"] = function(node, children)
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
+      ["else"] = {
+         ["before"] = function(node)
+            table.remove(st)
+            table.insert(st, {})
+            local f = facts_not(node.parent_if.exp.facts)
+            for _, elseifnode in ipairs(node.parent_if.elseifs) do
+               f = facts_and(f, facts_not(elseifnode.exp.facts), node)
+            end
+            apply_facts(node, f)
+         end,
+         ["after"] = function(node, children)
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
+      ["while"] = {
+         ["before"] = function()
+
+            widen_all_unions()
+         end,
+         ["before_statements"] = function(node)
+            table.insert(st, {})
+            apply_facts(node.exp, node.exp.facts)
+         end,
+         ["after"] = function(node, children)
+            table.remove(st)
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
+      ["repeat"] = {
+         ["before"] = function()
+
+            widen_all_unions()
+         end,
          ["after"] = function(node, children)
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
@@ -4736,6 +5159,13 @@ function tl.type_check(ast, opts)
                node.type = type_check_index(node, node.e2, a, b)
             elseif node.op.op == "as" then
                node.type = b
+            elseif node.op.op == "is" then
+               if node.e1.kind == "variable" then
+                  node.facts = { [1] = { ["fact"] = "is", ["var"] = node.e1.tk, ["typ"] = b, }, }
+               else
+                  node_error(node, "can only use 'is' on variables")
+               end
+               node.type = BOOLEAN
             elseif node.op.op == "." then
                a = resolve_unary(a, {})
                if a.typename == "map" then
@@ -4756,19 +5186,25 @@ function tl.type_check(ast, opts)
             elseif node.op.op == ":" then
                node.type = match_record_key(node, node.e1.type, node.e2, orig_a)
             elseif node.op.op == "not" then
+               node.facts = facts_not(node.e1.facts)
                node.type = BOOLEAN
             elseif node.op.op == "and" then
+               node.facts = facts_and(node.e1.facts, node.e2.facts, node)
                node.type = resolve_tuple(b)
             elseif node.op.op == "or" and b.typename == "emptytable" then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and same_type(resolve_unary(a), resolve_unary(b)) then
+               node.facts = facts_or(node.e1.facts, node.e2.facts)
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and b.typename == "nil" then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and
                (a.typename == "nominal" or a.typename == "map") and
                (b.typename == "record" or b.typename == "arrayrecord") and
                is_a(b, a) then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "==" or node.op.op == "~=" then
                if is_a(a, b, {}, true) or is_a(b, a, {}, true) then
@@ -4792,6 +5228,10 @@ function tl.type_check(ast, opts)
                   end
                end
             elseif node.op.arity == 2 and binop_types[node.op.op] then
+               if node.op.op == "or" then
+                  node.facts = facts_or(node.e1.facts, node.e2.facts)
+               end
+
                a = resolve_unary(a)
                b = resolve_unary(b)
                local types_op = binop_types[node.op.op]
@@ -4833,12 +5273,7 @@ function tl.type_check(ast, opts)
       },
    }
 
-   visit_node.cbs["while"] = visit_node.cbs["if"]
-   visit_node.cbs["repeat"] = visit_node.cbs["if"]
-   visit_node.cbs["do"] = visit_node.cbs["if"]
-   visit_node.cbs["break"] = visit_node.cbs["if"]
-   visit_node.cbs["elseif"] = visit_node.cbs["if"]
-   visit_node.cbs["else"] = visit_node.cbs["if"]
+   visit_node.cbs["break"] = visit_node.cbs["do"]
 
    visit_node.cbs["values"] = visit_node.cbs["variables"]
    visit_node.cbs["expression_list"] = visit_node.cbs["variables"]

--- a/tl.lua
+++ b/tl.lua
@@ -1973,6 +1973,7 @@ local VisitorCallbacks = {}
 
 
 
+
 local Visitor = {}
 
 
@@ -2123,6 +2124,9 @@ visit_type)
       end
       xs[2] = p1
       if ast.op.arity == 2 then
+         if cbs.before_e2 then
+            cbs.before_e2(ast, xs)
+         end
          xs[3] = recurse_node(ast.e2, visit_node, visit_type)
          xs[4] = (ast.e2.op and ast.e2.op.prec)
       end
@@ -5334,7 +5338,19 @@ function tl.type_check(ast, opts)
          end,
       },
       ["op"] = {
+         ["before"] = function(node)
+            begin_scope()
+         end,
+         ["before_e2"] = function(node)
+            if node.op.op == "and" then
+               apply_facts(node, node.e1.facts)
+            elseif node.op.op == "or" then
+               apply_facts(node, facts_not(node.e1.facts))
+            end
+         end,
          ["after"] = function(node, children)
+            end_scope()
+
             local a = children[1]
             local b = children[3]
             local orig_a = a

--- a/tl.lua
+++ b/tl.lua
@@ -65,6 +65,7 @@ local TokenKind = {}
 
 
 
+
 local Token = {}
 
 
@@ -116,7 +117,7 @@ for c = string.byte("A"), string.byte("F") do
 end
 
 local lex_char_symbols = {}
-for _, c in ipairs({ [1] = "[", [2] = "]", [3] = "(", [4] = ")", [5] = "{", [6] = "}", [7] = ",", [8] = ":", [9] = "#", [10] = "`", [11] = ";", }) do
+for _, c in ipairs({ [1] = "[", [2] = "]", [3] = "(", [4] = ")", [5] = "{", [6] = "}", [7] = ",", [8] = "#", [9] = "`", [10] = ";", }) do
    lex_char_symbols[c] = true
 end
 
@@ -131,6 +132,7 @@ for _, c in ipairs({ [1] = " ", [2] = "\t", [3] = "\v", [4] = "\n", [5] = "\r", 
 end
 
 local LexState = {}
+
 
 
 
@@ -266,6 +268,9 @@ function tl.lex(input)
          elseif c == "<" then
             state = "lt"
             begin_token()
+         elseif c == ":" then
+            state = "colon"
+            begin_token()
          elseif c == ">" then
             state = "gt"
             begin_token()
@@ -364,6 +369,15 @@ function tl.lex(input)
             state = "any"
          else
             end_token("op", i - 1)
+            fwd = false
+            state = "any"
+         end
+      elseif state == "colon" then
+         if c == ":" then
+            end_token("::")
+            state = "any"
+         else
+            end_token(":", i - 1)
             fwd = false
             state = "any"
          end
@@ -686,7 +700,11 @@ local TypeName = {}
 
 
 
+
 local Type = {}
+
+
+
 
 
 
@@ -804,6 +822,8 @@ local NodeKind = {}
 
 
 
+
+
 local FactType = {}
 
 
@@ -815,6 +835,9 @@ local Fact = {}
 
 
 local Node = {}
+
+
+
 
 
 
@@ -1640,6 +1663,23 @@ local function parse_break(tokens, i, errs)
    return i, node
 end
 
+local function parse_goto(tokens, i, errs)
+   local node = new_node(tokens, i, "goto")
+   i = verify_tk(tokens, i, errs, "goto")
+   node.label = tokens[i].tk
+   i = verify_kind(tokens, i, errs, "identifier")
+   return i, node
+end
+
+local function parse_label(tokens, i, errs)
+   local node = new_node(tokens, i, "label")
+   i = verify_tk(tokens, i, errs, "::")
+   node.label = tokens[i].tk
+   i = verify_kind(tokens, i, errs, "identifier")
+   i = verify_tk(tokens, i, errs, "::")
+   return i, node
+end
+
 local stop_statement_list = {
    ["end"] = true,
    ["else"] = true,
@@ -1861,6 +1901,10 @@ local function parse_statement(tokens, i, errs)
       return parse_break(tokens, i, errs)
    elseif tokens[i].tk == "return" then
       return parse_return(tokens, i, errs)
+   elseif tokens[i].tk == "goto" then
+      return parse_goto(tokens, i, errs)
+   elseif tokens[i].tk == "::" then
+      return parse_label(tokens, i, errs)
    else
       return parse_call_or_assignment(tokens, i, errs)
    end
@@ -2072,6 +2116,8 @@ visit_type)
       ast.kind == "string" or
       ast.kind == "number" or
       ast.kind == "break" or
+      ast.kind == "goto" or
+      ast.kind == "label" or
       ast.kind == "nil" or
       ast.kind == "..." or
       ast.kind == "boolean" then
@@ -2545,6 +2591,23 @@ function tl.pretty_print_ast(ast, fast)
          ["after"] = function(node, children)
             local out = { ["y"] = node.y, ["h"] = 0, }
             table.insert(out, "{}")
+            return out
+         end,
+      },
+      ["goto"] = {
+         ["after"] = function(node, children)
+            local out = { ["y"] = node.y, ["h"] = 0, }
+            table.insert(out, "goto ")
+            table.insert(out, node.label)
+            return out
+         end,
+      },
+      ["label"] = {
+         ["after"] = function(node, children)
+            local out = { ["y"] = node.y, ["h"] = 0, }
+            table.insert(out, "::")
+            table.insert(out, node.label)
+            table.insert(out, "::")
             return out
          end,
       },
@@ -4234,8 +4297,30 @@ function tl.type_check(ast, opts)
       st[1][var] = { ["t"] = valtype, ["is_const"] = is_const, }
    end
 
-   local function begin_function_scope(node, recurse)
+   local function begin_scope()
       table.insert(st, {})
+   end
+
+   local function end_scope()
+      local unresolved = st[#st]["@unresolved"]
+      if unresolved then
+         local upper = st[#st - 1]["@unresolved"]
+         if upper then
+            for name, nodes in pairs(unresolved.t.labels) do
+               for _, node in ipairs(nodes) do
+                  upper.t.labels[name] = upper.t.labels[name] or {}
+                  table.insert(upper.t.labels[name], node)
+               end
+            end
+         else
+            st[#st - 1]["@unresolved"] = unresolved
+         end
+      end
+      table.remove(st)
+   end
+
+   local function begin_function_scope(node, recurse)
+      begin_scope()
       local args = {}
       for i, arg in ipairs(node.args) do
          local t = arg.decltype
@@ -4262,8 +4347,21 @@ function tl.type_check(ast, opts)
       end
    end
 
+   local function fail_unresolved_labels()
+      local unresolved = st[#st]["@unresolved"]
+      if unresolved then
+         st[#st]["@unresolved"] = nil
+         for name, nodes in pairs(unresolved.t.labels) do
+            for _, node in ipairs(nodes) do
+               node_error(node, "no visible label '" .. name .. "' for goto")
+            end
+         end
+      end
+   end
+
    local function end_function_scope()
-      table.remove(st)
+      fail_unresolved_labels()
+      end_scope()
    end
 
    local function flatten_list(list)
@@ -4654,10 +4752,15 @@ function tl.type_check(ast, opts)
    visit_node.cbs = {
       ["statements"] = {
          ["before"] = function()
-            table.insert(st, {})
+            begin_scope()
          end,
          ["after"] = function(node, children)
-            table.remove(st)
+
+            if #st == 2 then
+               fail_unresolved_labels()
+            end
+
+            end_scope()
 
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
@@ -4773,18 +4876,18 @@ function tl.type_check(ast, opts)
       },
       ["if"] = {
          ["before_statements"] = function(node)
-            table.insert(st, {})
+            begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
          ["after"] = function(node, children)
-            table.remove(st)
+            end_scope()
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
       },
       ["elseif"] = {
          ["before"] = function(node)
-            table.remove(st)
-            table.insert(st, {})
+            end_scope()
+            begin_scope()
          end,
          ["before_statements"] = function(node)
             local f = facts_not(node.parent_if.exp.facts)
@@ -4800,8 +4903,8 @@ function tl.type_check(ast, opts)
       },
       ["else"] = {
          ["before"] = function(node)
-            table.remove(st)
-            table.insert(st, {})
+            end_scope()
+            begin_scope()
             local f = facts_not(node.parent_if.exp.facts)
             for _, elseifnode in ipairs(node.parent_if.elseifs) do
                f = facts_and(f, facts_not(elseifnode.exp.facts), node)
@@ -4818,11 +4921,41 @@ function tl.type_check(ast, opts)
             widen_all_unions()
          end,
          ["before_statements"] = function(node)
-            table.insert(st, {})
+            begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
          ["after"] = function(node, children)
-            table.remove(st)
+            end_scope()
+            node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
+         end,
+      },
+      ["label"] = {
+         ["before"] = function(node)
+
+            widen_all_unions()
+            local label_id = "::" .. node.label .. "::"
+            if st[#st][label_id] then
+               node_error(node, "label '" .. node.label .. "' already defined at " .. filename)
+            end
+            local unresolved = st[#st]["@unresolved"]
+            if unresolved then
+               unresolved.t.labels[node.label] = nil
+            end
+            node.type = { ["y"] = node.y, ["x"] = node.x, ["typeid"] = new_typeid(), ["typename"] = "none", }
+            add_var(node, label_id, node.type)
+         end,
+      },
+      ["goto"] = {
+         ["after"] = function(node, children)
+            if not find_var("::" .. node.label .. "::") then
+               local unresolved = find_var("@unresolved")
+               if not unresolved then
+                  unresolved = { ["typename"] = "unresolved_labels", ["labels"] = {}, }
+                  add_var(node, "@unresolved", unresolved)
+               end
+               unresolved.labels[node.label] = unresolved.labels[node.label] or {}
+               table.insert(unresolved.labels[node.label], node)
+            end
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
       },
@@ -4837,7 +4970,7 @@ function tl.type_check(ast, opts)
       },
       ["forin"] = {
          ["before"] = function()
-            table.insert(st, {})
+            begin_scope()
          end,
          ["before_statements"] = function(node)
             local exp1 = node.exps[1]
@@ -4867,17 +5000,17 @@ function tl.type_check(ast, opts)
             end
          end,
          ["after"] = function(node, children)
-            table.remove(st)
+            end_scope()
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
       },
       ["fornum"] = {
          ["before"] = function(node)
-            table.insert(st, {})
+            begin_scope()
             add_var(nil, node.var.tk, NUMBER)
          end,
          ["after"] = function(node, children)
-            table.remove(st)
+            end_scope()
             node.type = { ["typeid"] = new_typeid(), ["typename"] = "none", }
          end,
       },

--- a/tl.tl
+++ b/tl.tl
@@ -668,7 +668,7 @@ end
 
 local TypeKind = enum
    "typedecl"
-   "typevar_list"
+   "typearg_list"
    "typeval_list"
    "type_list"
 end
@@ -676,6 +676,7 @@ end
 local TypeName = enum
    "typetype"
    "typevar"
+   "typearg"
    "function"
    "array"
    "map"
@@ -731,7 +732,7 @@ local Type = record
    values: Type
 
    -- records
-   typevars: {Type}
+   typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
 
@@ -752,6 +753,9 @@ local Type = record
 
    -- typevar
    typevar: string
+
+   -- typearg
+   typearg: string
 
    -- table items
    kname: string
@@ -848,7 +852,7 @@ local Node = record
    key: Node
    value: Node
 
-   typevars: Type
+   typeargs: Type
    args: Node
    rets: Type
    body: Node
@@ -1013,7 +1017,7 @@ local SeparatorMode = enum
    "term"
 end
 
-local function parse_list(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, close: {string:boolean}, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
+local function parse_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, close: {string:boolean}, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
    local n = 1
    while tokens[i].kind ~= "$EOF$" do
       if close[tokens[i].tk] then
@@ -1035,7 +1039,7 @@ local function parse_list(tokens: {Token}, i: number, errs: {ParseError}, list: 
    return i, list
 end
 
-local function parse_bracket_list(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, open: string, close: string, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
+local function parse_bracket_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, open: string, close: string, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
    i = verify_tk(tokens, i, errs, open)
    i = parse_list(tokens, i, errs, list, { [close] = true }, sep, parse_item)
    i = verify_tk(tokens, i, errs, close)
@@ -1047,7 +1051,7 @@ local function parse_table_literal(tokens: {Token}, i: number, errs: {ParseError
    return parse_bracket_list(tokens, i, errs, node, "{", "}", "term", parse_table_item)
 end
 
-local function parse_trying_list(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, parse_item: ParseItem<`T>): number, {`T}
+local function parse_trying_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, parse_item: ParseItem<`T>): number, {`T}
    local tryerrs: {ParseError} = {}
    local tryi, item = parse_item(tokens, i, tryerrs)
    if not item then
@@ -1068,6 +1072,19 @@ local function parse_trying_list(tokens: {Token}, i: number, errs: {ParseError},
    return i, list
 end
 
+local function parse_typearg_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
+   i = verify_tk(tokens, i, errs, "`")
+   i = verify_kind(tokens, i, errs, "identifier")
+   return i, {
+      typeid = new_typeid(),
+      y = tokens[i - 2].y,
+      x = tokens[i - 2].x,
+      kind = "typedecl",
+      typename = "typearg",
+      typearg = "`" .. tokens[i-1].tk,
+   }
+end
+
 local function parse_typevar_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
    i = verify_tk(tokens, i, errs, "`")
    i = verify_kind(tokens, i, errs, "identifier")
@@ -1081,9 +1098,9 @@ local function parse_typevar_type(tokens: {Token}, i: number, errs: {ParseError}
    }
 end
 
-local function parse_typevar_list(tokens: {Token}, i: number, errs: {ParseError}): number, Type
-   local typ = new_type(tokens, i, "typevar_list")
-   return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_typevar_type)
+local function parse_typearg_list(tokens: {Token}, i: number, errs: {ParseError}): number, Type
+   local typ = new_type(tokens, i, "typearg_list")
+   return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_typearg_type)
 end
 
 local function parse_typeval_list(tokens: {Token}, i: number, errs: {ParseError}): number, Type
@@ -1102,7 +1119,7 @@ local function parse_function_type(tokens: {Token}, i: number, errs: {ParseError
       rets = {},
    }
    if tokens[i].tk == "<" then
-      i, node.typevars = parse_typevar_list(tokens, i, errs)
+      i, node.typeargs = parse_typearg_list(tokens, i, errs)
    end
    if tokens[i].tk == "(" then
       i, node.args = parse_argument_type_list(tokens, i, errs)
@@ -1205,6 +1222,7 @@ end
 
 parse_type_list = function(tokens: {Token}, i: number, errs: {ParseError}, open: string): number, Type
    local list = new_type(tokens, i, "type_list")
+   list.typename = "tuple"
    if tokens[i].tk == (open or ":") then
       i = i + 1
       local optional_paren = false
@@ -1224,7 +1242,7 @@ end
 
 local function parse_function_args_rets_body(tokens: {Token}, i: number, errs: {ParseError}, node: Node): number, Node
    if tokens[i].tk == "<" then
-      i, node.typevars = parse_typevar_list(tokens, i, errs)
+      i, node.typeargs = parse_typearg_list(tokens, i, errs)
    end
    i, node.args = parse_argument_list(tokens, i, errs)
    i, node.rets = parse_type_list(tokens, i, errs)
@@ -1501,6 +1519,7 @@ end
 
 parse_argument_type_list = function(tokens: {Token}, i: number, errs: {ParseError}): number, Type
    local list = new_type(tokens, i, "type_list")
+   list.typename = "tuple"
    return parse_bracket_list(tokens, i, errs, list, "(", ")", "sep", parse_argument_type)
 end
 
@@ -1724,7 +1743,7 @@ parse_newtype = function(tokens: {Token}, i: number, errs: {ParseError}): number
       def.field_order = {}
       i = i + 1
       if tokens[i].tk == "<" then
-         i, def.typevars = parse_typevar_list(tokens, i, errs)
+         i, def.typeargs = parse_typearg_list(tokens, i, errs)
       end
       while not ((not tokens[i]) or tokens[i].tk == "end") do
          if tokens[i].tk == "{" then
@@ -1959,14 +1978,14 @@ local Visitor = record<`K, `N, `T>
    after: VisitorCallbacks<`N, `T>
 end
 
-local function visit_before(ast: `N, kind: `K, visit: Visitor<`K,`N,`T>): `T
+local function visit_before<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K,`N,`T>): `T
    assert(visit.cbs[kind], "no visitor for " .. (kind as string))
    if visit.cbs[kind].before then
       visit.cbs[kind].before(ast)
    end
 end
 
-local function visit_after(ast: `N, kind: `K, visit: Visitor<`K, `N,`T>, xs: {`T}): `T
+local function visit_after<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K, `N,`T>, xs: {`T}): `T
    if visit.after and visit.after.before then
       visit.after.before(ast, xs)
    end
@@ -1983,7 +2002,9 @@ end
 local function recurse_type(ast: Type, visit: Visitor<TypeKind, Type, `T>): `T
    visit_before(ast, ast.kind, visit)
    local xs: {`T} = {}
-   if ast.kind == "type_list" then
+   if ast.kind == "type_list"
+   or ast.kind == "typevar_list"
+   or ast.kind == "typearg_list" then
       for i, child in ipairs(ast) do
          xs[i] = recurse_type(child, visit)
       end
@@ -1997,9 +2018,9 @@ local function recurse_type(ast: Type, visit: Visitor<TypeKind, Type, `T>): `T
    return visit_after(ast, ast.kind, visit, xs)
 end
 
-local function recurse_node(ast: Node,
-                            visit_node: Visitor<NodeKind, Node, `T>,
-                            visit_type: Visitor<TypeKind, Type, `T>): `T
+local function recurse_node<`T>(ast: Node,
+                                visit_node: Visitor<NodeKind, Node, `T>,
+                                visit_type: Visitor<TypeKind, Type, `T>): `T
    if not ast then
       -- parse error
       return
@@ -2100,10 +2121,10 @@ local function recurse_node(ast: Node,
       if ast.op.op == ":" and ast.e1.kind == "string" then
          p1 = -999
       end
-      xs[2] = p1
+      xs[2] = p1 as `T
       if ast.op.arity == 2 then
          xs[3] = recurse_node(ast.e2, visit_node, visit_type)
-         xs[4] = ast.e2.op and ast.e2.op.prec
+         xs[4] = (ast.e2.op and ast.e2.op.prec) as `T
       end
    elseif ast.kind == "newtype" then
       xs[1] = recurse_type(ast.newtype, visit_type)
@@ -2650,6 +2671,8 @@ local VARARG_STRING = { typeid = new_typeid(), typename = "string", is_va = true
 local VARARG_NUMBER = { typeid = new_typeid(), typename = "number", is_va = true }
 local VARARG_UNKNOWN = { typeid = new_typeid(), typename = "unknown", is_va = true }
 local BOOLEAN = { typeid = new_typeid(), typename = "boolean" }
+local ARG_ALPHA = { typeid = new_typeid(), typename = "typearg", typearg = "`a" }
+local ARG_BETA = { typeid = new_typeid(), typename = "typearg", typearg = "`b" }
 local ALPHA = { typeid = new_typeid(), typename = "typevar", typevar = "`a" }
 local BETA = { typeid = new_typeid(), typename = "typevar", typevar = "`b" }
 local ARRAY_OF_ANY = { typeid = new_typeid(), typename = "array", elements = ANY }
@@ -2817,43 +2840,16 @@ local binop_types: {string:{TypeName:{TypeName:Type}}} = {
    },
 }
 
-local show_type: function(Type, {string:Type}): string
-
-local function resolve_typevars(t: Type, typevars: {string:Type}, seen: {Type:Type}): Type
-   seen = seen or {}
-   if seen[t] then
-      return seen[t]
-   end
-
-   local orig_t = t
-   if t.typename == "typevar" and typevars[t.typevar] then
-      t = typevars[t.typevar]
-      t.tk = nil
-   end
-
-   local copy: Type = {}
-   seen[orig_t] = copy
-
-   for k, v in pairs(t as {string:Type}) do
-      local cp = copy as {string:Type}
-      if type(v) == "table" then
-         cp[k] = resolve_typevars(v, typevars, seen)
-      else
-         cp[k] = v
-      end
-   end
-
-   return copy
-end
+local show_type: function(Type): string
 
 local function is_unknown(t: Type): boolean
    return t.typename == "unknown"
        or t.typename == "unknown_emptytable_value"
 end
 
-local show_type: function(Type, {string:Type}, {Type:boolean}): string
+local show_type: function(Type, {Type:boolean}): string
 
-local function show_type_base(t: Type, typevars: {string:Type}, seen: {Type:boolean}): string
+local function show_type_base(t: Type, seen: {Type:boolean}): string
    -- FIXME this is a control for recursively built types, which should in principle not exist
    if seen[t] then
       return "..."
@@ -2861,12 +2857,9 @@ local function show_type_base(t: Type, typevars: {string:Type}, seen: {Type:bool
    seen[t] = true
 
    local function show(t: Type): string
-      return show_type(t, typevars, seen)
+      return show_type(t, seen)
    end
 
-   if typevars then
-      t = resolve_typevars(t, typevars)
-   end
    if t.typename == "nominal" then
       if t.typevals then
          local out = { table.concat(t.names, "."), "<" }
@@ -2944,6 +2937,8 @@ local function show_type_base(t: Type, typevars: {string:Type}, seen: {Type:bool
              (t.tk and " " .. t.tk or "")
    elseif t.typename == "typevar" then
       return t.typevar
+   elseif t.typename == "typearg" then
+      return t.typearg
    elseif is_unknown(t) then
       return "<unknown type>"
    elseif t.typename == "invalid" then
@@ -2961,8 +2956,8 @@ local function show_type_base(t: Type, typevars: {string:Type}, seen: {Type:bool
    end
 end
 
-show_type = function(t: Type, typevars: {string:Type}, seen: {Type:boolean}): string
-   local ret = show_type_base(t, typevars, seen or {})
+show_type = function(t: Type, seen: {Type:boolean}): string
+   local ret = show_type_base(t, seen or {})
    if t.inferred_at then
       ret = ret .. " (inferred at "..t.inferred_at_file..":"..t.inferred_at.y..":"..t.inferred_at.x..": )"
    end
@@ -3072,24 +3067,24 @@ local standard_library: {string:Type} = {
    ["any"] = { typeid = new_typeid(), typename = "typetype", def = ANY },
    ["arg"] = ARRAY_OF_STRING,
    ["require"] = { typeid = new_typeid(), typename = "function", args = { STRING }, rets = {} },
-   ["setmetatable"] = { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ALPHA, METATABLE }, rets = { ALPHA } },
+   ["setmetatable"] = { typeid = new_typeid(), typeargs = { ARG_ALPHA }, typename = "function", args = { ALPHA, METATABLE }, rets = { ALPHA } },
    ["getmetatable"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = { METATABLE } },
    ["rawget"] = { typeid = new_typeid(), typename = "function", args = { TABLE, ANY }, rets = { ANY } },
    ["rawset"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA, BETA }, rets = {} },
-         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA, BETA }, rets = {} },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
          { typeid = new_typeid(), typename = "function", args = { TABLE, ANY, ANY }, rets = {} },
       }
    },
    ["next"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA }, rets = { ALPHA, BETA } },
-         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA }, rets = { ALPHA, BETA } },
-         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA }, rets = { NUMBER, ALPHA } },
-         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, ALPHA }, rets = { NUMBER, ALPHA } },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA }, rets = { ALPHA, BETA } },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA }, rets = { ALPHA, BETA } },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA }, rets = { NUMBER, ALPHA } },
+         { typeid = new_typeid(), typeargs = { ARG_ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, ALPHA }, rets = { NUMBER, ALPHA } },
       },
    },
    ["load"] = {
@@ -3130,7 +3125,7 @@ local standard_library: {string:Type} = {
             ["__call"] = FUNCTION,
             ["__gc"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = {} },
             ["__len"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = { NUMBER } },
-            ["__pairs"] = { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
+            ["__pairs"] = { typeid = new_typeid(), typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
                   { typeid = new_typeid(), typename = "function", args = {}, rets = { ALPHA, BETA } },
             } },
             -- TODO complete...
@@ -3193,29 +3188,29 @@ local standard_library: {string:Type} = {
          ["unpack"] = {
             typeid = new_typeid(), typename = "function",
             needs_compat53 = true,
-            typevars = { ALPHA },
+            typeargs = { ARG_ALPHA },
             args = { ARRAY_OF_ALPHA, NUMBER, NUMBER },
             rets = { { typeid = new_typeid(), typename = "typevar", typevar = "`a", is_va = true }
          } },
          ["move"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER }, rets = { ARRAY_OF_ALPHA } },
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER, ARRAY_OF_ALPHA }, rets = { ARRAY_OF_ALPHA } },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER }, rets = { ARRAY_OF_ALPHA } },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER, ARRAY_OF_ALPHA }, rets = { ARRAY_OF_ALPHA } },
             }
          },
          ["insert"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, ALPHA }, rets = {} },
             }
          },
          ["remove"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER }, rets = { ALPHA } },
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = { ALPHA } },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER }, rets = { ALPHA } },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA }, rets = { ALPHA } },
             }
          },
          ["concat"] = {
@@ -3228,8 +3223,8 @@ local standard_library: {string:Type} = {
          ["sort"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {} },
-               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, { typeid = new_typeid(), typename = "function", args = { ALPHA, ALPHA }, rets = { BOOLEAN } } }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, { typeid = new_typeid(), typename = "function", args = { ALPHA, ALPHA }, rets = { BOOLEAN } } }, rets = {} },
             }
          }
       },
@@ -3294,24 +3289,24 @@ local standard_library: {string:Type} = {
          ["offset"] = { typeid = new_typeid(), typename = "function", args = { STRING, NUMBER, NUMBER }, rets = { NUMBER } },
       },
    },
-   ["ipairs"] = { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {
+   ["ipairs"] = { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {
       { typeid = new_typeid(), typename = "function", args = {}, rets = { NUMBER, ALPHA } },
    } },
-   ["pairs"] = { typeid = new_typeid(), typename = "function", typevars = { ALPHA, BETA }, args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
+   ["pairs"] = { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
       { typeid = new_typeid(), typename = "function", args = {}, rets = { ALPHA, BETA } },
    } },
    ["pcall"] = { typeid = new_typeid(), typename = "function", args = { VARARG_ANY }, rets = { BOOLEAN, ANY } },
    ["assert"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ALPHA }, rets = { ALPHA } },
-         { typeid = new_typeid(), typename = "function", typevars = { ALPHA, BETA }, args = { ALPHA, BETA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { ALPHA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { ALPHA, BETA }, rets = { ALPHA } },
       }
    },
    ["select"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { NUMBER, ALPHA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typeargs = { ARG_ALPHA }, args = { NUMBER, ALPHA }, rets = { ALPHA } },
          { typeid = new_typeid(), typename = "function", args = { STRING, VARARG_ANY }, rets = { NUMBER } },
       }
    },
@@ -3468,6 +3463,43 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
+   local function resolve_typevars(t: Type, seen: {Type:Type}): Type
+      seen = seen or {}
+      if seen[t] then
+         return seen[t]
+      end
+
+      local orig_t = t
+      local clear_tk = false
+      if t.typename == "typevar" then
+         local tv = find_var(t.typevar)
+         if tv then
+            t = tv
+            clear_tk = true
+         else
+            t = UNKNOWN
+         end
+      end
+
+      local copy: Type = {}
+      seen[orig_t] = copy
+
+      for k, v in pairs(t as {string:Type}) do
+         local cp = copy as {string:Type}
+         if type(v) == "table" then
+            cp[k] = resolve_typevars(v, seen)
+         else
+            cp[k] = v
+         end
+      end
+
+      if clear_tk then
+         copy.tk = nil
+      end
+
+      return copy
+   end
+
    local function find_type(names: {string}): Type
       local typ = find_var(names[1])
       if not typ then
@@ -3560,101 +3592,53 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return node.type
    end
 
-
-   local function match_typevals(t: Type, def: Type, typevars: {string:Type}): Type
-      if not typevars then
-         return def
-      end
-
-      if t.typevals and def.typevars then
-         if #t.typevals ~= #def.typevars then
-            type_error(t, "mismatch in number of type arguments")
-            return nil
-         end
-
-         local newtypevars: {string:Type} = {}
-         for k,v in pairs(typevars) do
-            newtypevars[k] = v
-         end
-         for i, tt in ipairs(t.typevals) do
-            newtypevars[def.typevars[i].typevar] = tt
-         end
-         return resolve_typevars(def, newtypevars)
-      elseif t.typevals then
-         type_error(t, "spurious type arguments")
-         return nil
-      elseif def.typevars then
-         type_error(t, "missing type arguments in %s", def)
-         return nil
-      else
-         return def
-      end
-   end
-
-   local function resolve_nominal(t: Type, typevars: {string:Type}): Type
-      if t.resolved then
-         return t.resolved
-      end
-
-      local resolved: Type
-
-      local typetype = find_type(t.names)
-      if not typetype then
-         type_error(t, "unknown type %s", t)
-      elseif typetype.typename == "typetype" then
-         resolved = match_typevals(t, typetype.def, typevars)
-      else
-         type_error(t, table.concat(t.names, ".") .. " is not a type")
-      end
-
-      if not resolved then
-         resolved = { typeid = new_typeid(), typename = "bad_nominal", names = t.names }
-      end
-
-      t.resolved = resolved
-      return resolved
-   end
-
-   local function resolve_unary(t: Type, typevars: {string:Type}): Type
-      t = resolve_tuple(t)
-      if t.typename == "nominal" then
-         return resolve_nominal(t, typevars)
-      end
-      return t
-   end
-
    local function terr(t: Type, s: string, ...: Type): {Error}
       return { error_in_type(t, s, ...) }
    end
 
-   local CompareTypes = functiontype(Type, Type, {string:Type}, boolean): boolean, {Error}
+   local function add_unknown(node: Node, name: string)
+      table.insert(unknowns, { y = node.y, x = node.x, msg = name, filename = filename })
+   end
 
-   local function compare_typevars(t1: Type, t2: Type, typevars: {string:Type}, comp: CompareTypes): boolean, {Error}
-      if t1.typevar == t2.typevar then
-         if not typevars then
-            return true
+   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean)
+      if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
+         add_unknown(node, var)
+      end
+      if st[#st][var] and is_narrowing then
+         if not st[#st][var].is_narrowed then
+            st[#st][var].narrowed_from = st[#st][var].t
          end
-         local has_t1 = not not typevars[t1.typevar]
-         local has_t2 = not not typevars[t2.typevar]
+         st[#st][var].is_narrowed = true
+         st[#st][var].t = valtype
+      else
+         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing }
+      end
+   end
+
+   local CompareTypes = functiontype(Type, Type, boolean): boolean, {Error}
+
+   local function compare_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
+      local tv1 = find_var(t1.typevar)
+      local tv2 = find_var(t2.typevar)
+      if t1.typevar == t2.typevar then
+         local has_t1 = not not tv1
+         local has_t2 = not not tv2
          if has_t1 == has_t2 then
             return true
          end
       end
-      if not typevars then
-         return false, terr(t1, "got %s, expected %s", t1, t2)
-      end
       local function cmp(k: string, v: Type, a: Type, b: Type): boolean, {Error}
-         if typevars[k] then
-            return comp(a, b, typevars)
+         if find_var(k) then
+            return comp(a, b)
          else
-            typevars[k] = resolve_typevars(v, typevars)
+            add_var(nil, k, resolve_typevars(v))
             return true
          end
       end
       if t2.typename == "typevar" then
-         return cmp(t2.typevar, t1, t1, typevars[t2.typevar])
+         return cmp(t2.typevar, t1, t1, tv2)
       else
-         return cmp(t1.typevar, t2, typevars[t1.typevar], t2)
+         return cmp(t1.typevar, t2, tv1, t2)
       end
    end
 
@@ -3673,11 +3657,11 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   local is_a: function(Type, Type, {string:Type}, boolean): boolean, {Error}
+   local is_a: function(Type, Type, boolean): boolean, {Error}
 
    local TypeGetter = functiontype(string): Type
 
-   local function match_record_fields(t1: Type, t2: TypeGetter, typevars: {string:Type}, cmp: CompareTypes): boolean, {Error}
+   local function match_record_fields(t1: Type, t2: TypeGetter, cmp: CompareTypes): boolean, {Error}
       cmp = cmp or is_a
       local fielderrs: {Error} = {}
       for _, k in ipairs(t1.field_order) do
@@ -3688,7 +3672,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                table.insert(fielderrs, error_in_type(f, "unknown field " .. k))
             end
          else
-            local match, errs = is_a(f, t2k, typevars)
+            local match, errs = is_a(f, t2k)
             add_errs_prefixing(errs, fielderrs, "record field doesn't match: " .. k .. ": ")
          end
       end
@@ -3698,19 +3682,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return true
    end
 
-   local function match_fields_to_record(t1: Type, t2: Type, typevars: {string:Type}, cmp: CompareTypes): boolean, {Error}
-      return match_record_fields(t1, function(k: string): Type return t2.fields[k] end, typevars, cmp)
+   local function match_fields_to_record(t1: Type, t2: Type, cmp: CompareTypes): boolean, {Error}
+      return match_record_fields(t1, function(k: string): Type return t2.fields[k] end, cmp)
    end
 
-   local function match_fields_to_map(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
-      if not match_record_fields(t1, function(_: string): Type return t2.values end, typevars) then
+   local function match_fields_to_map(t1: Type, t2: Type): boolean, {Error}
+      if not match_record_fields(t1, function(_: string): Type return t2.values end) then
          return false, { error_in_type(t1, "not all fields have type %s", t2.values) }
       end
       return true
    end
 
-   local function arg_check(cmp: CompareTypes, a: Type, b: Type, typevars: {string:Type}, at: Node, n: number, errs: {Error}): boolean
-      local matches, match_errs = cmp(a, b, typevars)
+   local function arg_check(cmp: CompareTypes, a: Type, b: Type, at: Node, n: number, errs: {Error}): boolean
+      local matches, match_errs = cmp(a, b)
       if not matches then
          add_errs_prefixing(match_errs, errs, "argument " .. n .. ": ", at)
          return false
@@ -3718,7 +3702,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return true
    end
 
-   -- only check names, not typevars
+   -- only check names, not type variables
    local function same_names(t1: Type, t2: Type): boolean
       if t1.resolved and t2.resolved then
          return t1.resolved.typeid == t2.resolved.typeid
@@ -3739,13 +3723,13 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   local same_type: function(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
+   local same_type: function(t1: Type, t2: Type): boolean, {Error}
 
-   local function has_all_types_of(t1s: {Type}, t2s: {Type}, typevars: {string:Type}): boolean
+   local function has_all_types_of(t1s: {Type}, t2s: {Type}): boolean
       for _, t1 in ipairs(t1s) do
          local found = false
          for _, t2 in ipairs(t2s) do
-            if same_type(t1, t2, typevars) then
+            if same_type(t1, t2) then
                found = true
                break
             end
@@ -3757,12 +3741,20 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return true
    end
 
-   same_type = function(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
+   local function any_errors(all_errs: {Error}): boolean, {Error}
+      if #all_errs == 0 then
+         return true
+      else
+         return false, all_errs
+      end
+   end
+
+   same_type = function(t1: Type, t2: Type): boolean, {Error}
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
       if t1.typename == "typevar" or t2.typename == "typevar" then
-         return compare_typevars(t1, t2, typevars, same_type)
+         return compare_typevars(t1, t2, same_type)
       end
 
       if t1.typename ~= t2.typename then
@@ -3771,10 +3763,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       if t1.typename == "array" then
          return same_type(t1.elements, t2.elements)
       elseif t1.typename == "map" then
-         return same_type(t1.keys, t2.keys) and same_type(t1.values, t2.values)
+         local all_errs = {}
+         local k_ok, k_errs = same_type(t1.keys, t2.keys)
+         if not k_ok then
+            add_errs_prefixing(k_errs, all_errs, "keys", t1 as Node)
+         end
+         local v_ok, v_errs = same_type(t1.values, t2.values)
+         if not v_ok then
+            add_errs_prefixing(v_errs, all_errs, "values", t1 as Node)
+         end
+         return any_errors(all_errs)
       elseif t1.typename == "union" then
-         if  has_all_types_of(t1.types, t2.types, typevars)
-         and has_all_types_of(t2.types, t1.types, typevars) then
+         if  has_all_types_of(t1.types, t2.types)
+         and has_all_types_of(t2.types, t1.types) then
             return true
          else
             return false, terr(t1, "got %s, expected %s", t1, t2)
@@ -3782,7 +3783,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       elseif t1.typename == "nominal" then
          return same_names(t1, t2)
       elseif t1.typename == "record" then
-         return match_fields_to_record(t1, t2, typevars, same_type)
+         return match_fields_to_record(t1, t2, same_type)
       elseif t1.typename == "function" then
          if #t1.args ~= #t2.args then
             return false, terr(t1, "different number of input arguments: got " .. #t1.args .. ", expected " .. #t2.args)
@@ -3792,23 +3793,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end
          local all_errs = {}
          for i = 1, #t1.args do
-            arg_check(same_type, t1.args[i], t2.args[i], typevars, t1 as Node, i, all_errs)
+            arg_check(same_type, t1.args[i], t2.args[i], t1 as Node, i, all_errs)
          end
          for i = 1, #t1.rets do
             local ok, errs = same_type(t1.rets[i], t2.rets[i])
             add_errs_prefixing(errs, all_errs, "return " .. i, t1 as Node)
          end
-         if #all_errs == 0 then
-            return true
-         else
-            return false, all_errs
-         end
+         return any_errors(all_errs)
       elseif t1.typename == "arrayrecord" then
          local ok, errs = same_type(t1.elements, t2.elements)
          if not ok then
             return ok, errs
          end
-         return match_fields_to_record(t1, t2, typevars, same_type)
+         return match_fields_to_record(t1, t2, same_type)
       end
       return true
    end
@@ -3835,7 +3832,9 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   is_a = function(t1: Type, t2: Type, typevars: {string:Type}, for_equality: boolean): boolean, {Error}
+   local resolve_unary: function(t: Type): Type = nil
+
+   is_a = function(t1: Type, t2: Type, for_equality: boolean): boolean, {Error}
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
@@ -3858,33 +3857,33 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
 
       if t1.typename == "typevar" or t2.typename == "typevar" then
-         return compare_typevars(t1, t2, typevars, is_a)
+         return compare_typevars(t1, t2, is_a)
       end
 
       if t2.typename == "any" then
          return true
       elseif t2.typename == "poly" then
          for _, t in ipairs(t2.poly) do
-            if is_a(t1, t, typevars, for_equality) then
+            if is_a(t1, t, for_equality) then
                return true
             end
          end
          return false, terr(t1, "no match with poly") -- don't expect these errors to show, should fix if they do
       elseif t1.typename == "union" and t2.typename == "union" then
-         if has_all_types_of(t1.types, t2.types, typevars) then
+         if has_all_types_of(t1.types, t2.types) then
             return true
          else
             return false, terr(t1, "got %s, expected %s", t1, t2)
          end
       elseif t2.typename == "union" then
          for _, t in ipairs(t2.types) do
-            if is_a(t1, t, typevars, for_equality) then
+            if is_a(t1, t, for_equality) then
                return true
             end
          end
       elseif t1.typename == "poly" then
          for _, t in ipairs(t1.poly) do
-            if is_a(t, t2, typevars, for_equality) then
+            if is_a(t, t2, for_equality) then
                return true
             end
          end
@@ -3898,7 +3897,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             elseif t1.typevals and t2.typevals and #t1.typevals == #t2.typevals then
                local all_errs = {}
                for i = 1, #t1.typevals do
-                  local ok, errs = same_type(t2.typevals[i], t1.typevals[i], typevars)
+                  local ok, errs = same_type(t2.typevals[i], t1.typevals[i])
                   add_errs_prefixing(errs, all_errs, "type parameter <" .. show_type(t1.typevals[i]) .. ">: ", t1 as Node)
                end
                if #all_errs == 0 then
@@ -3926,14 +3925,14 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             return false, terr(t1, "%s is not a member of %s", t1, t2)
          end
       elseif t1.typename == "nominal" or t2.typename == "nominal" then
-         local t1u = resolve_unary(t1, typevars)
-         local t2u = resolve_unary(t2, typevars)
-         local ok, errs = is_a(t1u, t2u, typevars)
+         local t1u = resolve_unary(t1)
+         local t2u = resolve_unary(t2)
+         local ok, errs = is_a(t1u, t2u)
          if errs and #errs == 1 then
             if errs[1].msg:match("^got ") then
-               --local got = t1.typename == "nominal" and t1.name or show_type(t1, typevars)
-               --local expected = t2.typename == "nominal" and t2.name or show_type(t2, typevars)
-               errs = terr(t1, "got %s, expected %s", t1, t2) -- FIXME typevars
+               --local got = t1.typename == "nominal" and t1.name or show_type(t1)
+               --local expected = t2.typename == "nominal" and t2.name or show_type(t2)
+               errs = terr(t1, "got %s, expected %s", t1, t2)
             end
          end
          return ok, errs
@@ -3941,22 +3940,22 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          return true
       elseif t2.typename == "array" then
          if t1.typename == "array" or t1.typename == "arrayrecord" then
-            return is_a(t1.elements, t2.elements, typevars)
+            return is_a(t1.elements, t2.elements)
          elseif t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, NUMBER, typevars)
-            local _, errs_values = is_a(t1.values, t2.elements, typevars)
+            local _, errs_keys = is_a(t1.keys, NUMBER)
+            local _, errs_values = is_a(t1.values, t2.elements)
             return combine_errs(errs_keys, errs_values)
          end
       elseif t2.typename == "record" then
          if t1.typename == "record" or t1.typename == "arrayrecord" then
-            return match_fields_to_record(t1, t2, typevars)
+            return match_fields_to_record(t1, t2)
          elseif t1.typename == "map" then
-            if not is_a(t1.keys, STRING, typevars) then
+            if not is_a(t1.keys, STRING) then
                return false, terr(t1, "map has non-string keys")
             end
             for _, fname in ipairs(t2.field_order) do
                local ftype = t2.fields[fname]
-               if not is_a(t1.values, ftype, typevars) then
+               if not is_a(t1.values, ftype) then
                   return false, terr(t1, "field " .. fname .. " is of type %s", ftype)
                end
             end
@@ -3964,29 +3963,29 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end
       elseif t2.typename == "arrayrecord" then
          if t1.typename == "array" then
-            return is_a(t1.elements, t2.elements, typevars)
+            return is_a(t1.elements, t2.elements)
          elseif t1.typename == "record" then
-            return match_fields_to_record(t1, t2, typevars)
+            return match_fields_to_record(t1, t2)
          elseif t1.typename == "arrayrecord" then
-            if not is_a(t1.elements, t2.elements, typevars) then
+            if not is_a(t1.elements, t2.elements) then
                return false, terr(t1, "array parts have incompatible element types")
             end
-            return match_fields_to_record(t1, t2, typevars)
+            return match_fields_to_record(t1, t2)
          end
       elseif t2.typename == "map" then
          if t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, t2.keys, typevars)
-            local _, errs_values = is_a(t2.values, t1.values, typevars)
+            local _, errs_keys = is_a(t1.keys, t2.keys)
+            local _, errs_values = is_a(t2.values, t1.values)
             if t2.values.typename == "any" then -- special-case hack for {any:any}
                errs_values = {}
             end
             return combine_errs(errs_keys, errs_values)
          elseif t1.typename == "array" then
-            local _, errs_keys = is_a(NUMBER, t2.keys, typevars)
-            local _, errs_values = is_a(t1.elements, t2.values, typevars)
+            local _, errs_keys = is_a(NUMBER, t2.keys)
+            local _, errs_values = is_a(t1.elements, t2.values)
             return combine_errs(errs_keys, errs_values)
          elseif t1.typename == "record" or t1.typename == "arrayrecord" then -- FIXME
-            if not is_a(t2.keys, STRING, typevars) then
+            if not is_a(t2.keys, STRING) then
                return false, terr(t1, "can't match a record to a map with non-string keys")
             end
             if t2.keys.typename == "enum" then
@@ -3996,7 +3995,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   end
                end
             end
-            return match_fields_to_map(t1, t2, typevars)
+            return match_fields_to_map(t1, t2)
          end
       elseif t1.typename == "function" and t2.typename == "function" then
          local all_errs = {}
@@ -4004,7 +4003,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             table.insert(all_errs, error_in_type(t1, "incompatible number of arguments"))
          else
             for i = (t1.is_method and 2 or 1), #t1.args do
-               arg_check(is_a, t1.args[i], t2.args[i] or ANY, typevars, nil, i, all_errs)
+               arg_check(is_a, t1.args[i], t2.args[i] or ANY, nil, i, all_errs)
             end
          end
          local diff_by_va = #t2.rets - #t1.rets == 1 and t2.rets[#t2.rets].is_va
@@ -4016,7 +4015,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                nrets = nrets - 1
             end
             for i = 1, nrets do
-               local ok, errs = is_a(t1.rets[i], t2.rets[i], typevars)
+               local ok, errs = is_a(t1.rets[i], t2.rets[i])
                add_errs_prefixing(errs, all_errs, "return " .. i .. ": ")
             end
          end
@@ -4034,7 +4033,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return false, terr(t1, "got %s, expected %s", t1, t2)
    end
 
-   local function assert_is_a(node: Node, t1: Type, t2: Type, typevars: {string:Type}, context: string, name: string)
+   local function assert_is_a(node: Node, t1: Type, t2: Type, context: string, name: string)
       t1 = resolve_tuple(t1)
       t2 = resolve_tuple(t2)
       if lax and (is_unknown(t1) or is_unknown(t2)) then
@@ -4057,15 +4056,36 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          return
       end
 
-      local match, match_errs = is_a(t1, t2, typevars)
+      local match, match_errs = is_a(t1, t2)
       add_errs_prefixing(match_errs, errors, "in " .. context .. ": ".. (name and (name .. ": ") or ""), node)
+   end
+
+   local function begin_scope()
+      table.insert(st, {})
+   end
+
+   local function end_scope()
+      local unresolved = st[#st]["@unresolved"]
+      if unresolved then
+         local upper = st[#st - 1]["@unresolved"]
+         if upper then
+            for name, nodes in pairs(unresolved.t.labels) do
+               for _, node in ipairs(nodes) do
+                  upper.t.labels[name] = upper.t.labels[name] or {}
+                  table.insert(upper.t.labels[name], node)
+               end
+            end
+         else
+            st[#st - 1]["@unresolved"] = unresolved
+         end
+      end
+      table.remove(st)
    end
 
    local type_check_function_call: function(Node, Type, {Type}, boolean, number): Type
    do
       local function try_match_func_args(node: Node, f: Type, args: {Type}, is_method: boolean, argdelta: number): Type, {Error}
          local ok = true
-         local typevars = {}
          local errs = {}
 
          if is_method then
@@ -4074,7 +4094,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             argdelta = 0
          end
 
-         if f.is_method and not is_method and not is_a(args[1], f.args[1], typevars) then
+         if f.is_method and not is_method and not is_a(args[1], f.args[1]) then
             table.insert(errs, { y = node.y, x = node.x, msg = "invoked method as a regular function: use ':' instead of '.'", filename = filename })
             return nil, errs
          end
@@ -4093,11 +4113,11 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                end
                if not lax then
                   ok = false
-                  table.insert(errs, { y = node.y, x = node.x, msg = "error in argument " .. (a + argdelta) .. ": missing argument of type " .. show_type(farg, typevars), filename = filename })
+                  table.insert(errs, { y = node.y, x = node.x, msg = "error in argument " .. (a + argdelta) .. ": missing argument of type " .. show_type(farg), filename = filename })
                end
             else
                local at = node.e2 and node.e2[a] or node
-               if not arg_check(is_a, arg, farg, typevars, at, (a + argdelta), errs) then
+               if not arg_check(is_a, arg, farg, at, (a + argdelta), errs) then
                   ok = false
                   break
                end
@@ -4105,12 +4125,22 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end
          if ok == true then
             f.rets.typename = "tuple"
-            return resolve_typevars(f.rets, typevars)
+            return resolve_typevars(f.rets)
          end
          return nil, errs
       end
 
-      type_check_function_call = function(node: Node, func: Type, args: {Type}, is_method: boolean, argdelta: number): Type
+      local function revert_typeargs(func: Type)
+         if func.typeargs then
+            for _, arg in ipairs(func.typeargs) do
+               if st[#st][arg.typearg] then
+                  st[#st][arg.typearg] = nil
+               end
+            end
+         end
+      end
+
+      local function check_call(node: Node, func: Type, args: {Type}, is_method: boolean, argdelta: number): Type
          assert(type(func) == "table")
          assert(type(args) == "table")
 
@@ -4118,7 +4148,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             func = { typeid = new_typeid(), typename = "function", args = { VARARG_UNKNOWN }, rets = { VARARG_UNKNOWN } }
          end
 
-         func = resolve_unary(func, {}) -- FIXME propagate typevars?
+         func = resolve_unary(func)
 
          args = args or {}
          local poly: Type = func.typename == "poly" and func or { poly = { func } }
@@ -4138,6 +4168,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                local matched, errs = try_match_func_args(node, f, args, is_method, argdelta)
                if matched then
                   return matched
+               else
+                  revert_typeargs(f)
                end
                first_errs = first_errs or errs
             end
@@ -4148,6 +4180,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                local matched, errs = try_match_func_args(node, f, args, is_method, argdelta)
                if matched then
                   return matched
+               else
+                  revert_typeargs(f)
                end
                first_errs = first_errs or errs
             end
@@ -4158,6 +4192,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                local matched, errs = try_match_func_args(node, f, args, is_method, argdelta)
                if matched then
                   return matched
+               else
+                  revert_typeargs(f)
                end
                first_errs = first_errs or errs
             end
@@ -4172,15 +4208,18 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end
 
          poly.poly[1].rets.typename = "tuple"
-         return poly.poly[1].rets
+         return resolve_typevars(poly.poly[1].rets)
+      end
+
+      type_check_function_call = function(node: Node, func: Type, args: {Type}, is_method: boolean, argdelta: number): Type
+         begin_scope()
+         local ret = check_call(node, func, args, is_method, argdelta)
+         end_scope()
+         return ret
       end
    end
 
    local unknown_dots: {string:boolean} = {}
-
-   local function add_unknown(node: Node, name: string)
-      table.insert(unknowns, { y = node.y, x = node.x, msg = name, filename = filename })
-   end
 
    local function add_unknown_dot(node: Node, name: string)
       if not unknown_dots[name] then
@@ -4247,21 +4286,6 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return node_error(node, "invalid key '" .. key.tk .. "' in " .. description)
    end
 
-   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean)
-      if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
-         add_unknown(node, var)
-      end
-      if st[#st][var] and is_narrowing then
-         if not st[#st][var].is_narrowed then
-            st[#st][var].narrowed_from = st[#st][var].t
-         end
-         st[#st][var].is_narrowed = true
-         st[#st][var].t = valtype
-      else
-         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing }
-      end
-   end
-
    local function widen_in_scope(scope: {string:Variable}, var: string): boolean
       if scope[var].is_narrowed then
          if scope[var].narrowed_from then
@@ -4305,31 +4329,42 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       st[1][var] = { t = valtype, is_const = is_const }
    end
 
-   local function begin_scope()
-      table.insert(st, {})
-   end
+   local check_typevars: function(node: Node, t: Type)
 
-   local function end_scope()
-      local unresolved = st[#st]["@unresolved"]
-      if unresolved then
-         local upper = st[#st - 1]["@unresolved"]
-         if upper then
-            for name, nodes in pairs(unresolved.t.labels) do
-               for _, node in ipairs(nodes) do
-                  upper.t.labels[name] = upper.t.labels[name] or {}
-                  table.insert(upper.t.labels[name], node)
-               end
-            end
-         else
-            st[#st - 1]["@unresolved"] = unresolved
+   local function check_all_typevars(node: Node, ts: {Type})
+      if ts ~= nil then
+         for _, arg in ipairs(ts) do
+            check_typevars(node, arg)
          end
       end
-      table.remove(st)
+   end
+
+   check_typevars = function(node: Node, t: Type)
+      if t == nil then
+         return
+      end
+      if t.typename == "typevar" then
+         if not find_var(t.typevar) then
+            node_error(node, "unknown type variable " .. t.typevar)
+         end
+         return
+      end
+      check_typevars(node, t.elements)
+      check_typevars(node, t.keys)
+      check_typevars(node, t.values)
+      check_all_typevars(node, t.typeargs)
+      check_all_typevars(node, t.args)
+      check_all_typevars(node, t.rets)
    end
 
    local function begin_function_scope(node: Node, recurse: boolean)
       begin_scope()
       local args = {}
+      if node.typeargs then
+         for i, arg in ipairs(node.typeargs) do
+            add_var(nil, arg.typearg, arg)
+         end
+      end
       for i, arg in ipairs(node.args) do
          local t = arg.decltype
          if not t then
@@ -4341,6 +4376,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                node_error(node, "'...' can only be last argument")
             end
          end
+         check_typevars(arg, t)
          table.insert(args, t)
          add_var(arg, arg.tk, t)
       end
@@ -4370,6 +4406,63 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
    local function end_function_scope()
       fail_unresolved_labels()
       end_scope()
+   end
+
+   local function match_typevals(t: Type, def: Type): Type
+      if t.typevals and def.typeargs then
+         if #t.typevals ~= #def.typeargs then
+            type_error(t, "mismatch in number of type arguments")
+            return nil
+         end
+
+         begin_scope()
+         for i, tt in ipairs(t.typevals) do
+            add_var(nil, def.typeargs[i].typearg, tt)
+         end
+         local ret = resolve_typevars(def)
+         end_scope()
+         return ret
+      elseif t.typevals then
+         type_error(t, "spurious type arguments")
+         return nil
+      elseif def.typeargs then
+         type_error(t, "missing type arguments in %s", def)
+         return nil
+      else
+         return def
+      end
+   end
+
+   local function resolve_nominal(t: Type): Type
+      if t.resolved then
+         return t.resolved
+      end
+
+      local resolved: Type
+
+      local typetype = find_type(t.names)
+      if not typetype then
+         type_error(t, "unknown type %s", t)
+      elseif typetype.typename == "typetype" then
+         resolved = match_typevals(t, typetype.def)
+      else
+         type_error(t, table.concat(t.names, ".") .. " is not a type")
+      end
+
+      if not resolved then
+         resolved = { typeid = new_typeid(), typename = "bad_nominal", names = t.names }
+      end
+
+      t.resolved = resolved
+      return resolved
+   end
+
+   resolve_unary = function(t: Type): Type
+      t = resolve_tuple(t)
+      if t.typename == "nominal" then
+         return resolve_nominal(t)
+      end
+      return t
    end
 
    local function flatten_list(list: {Type}): {Type}
@@ -4426,13 +4519,12 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 
    local function match_all_record_field_names(node: Node, a: Type, field_names: {string}, errmsg: string): Type
       local t: Type
-      local typevars: {string: Type} = {}
       for _ k in ipairs(field_names) do
          local f = a.fields[k]
          if not t then
             t = f
          else
-            if not same_type(f, t, typevars) then
+            if not same_type(f, t) then
                t = nil
                break
             end
@@ -4561,7 +4653,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          return vars
       end
 
-      local function intersect(xs: {`T}, ys: {`T}, same: function(`T, `T): boolean): {`T}
+      local function intersect<`T>(xs: {`T}, ys: {`T}, same: function(`T, `T): boolean): {`T}
          local rs = {}
          for i = #xs, 1, -1 do
             local x = xs[i]
@@ -4576,7 +4668,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
 
       local function same_type_for_intersect(t: Type, u: Type): boolean
-         return (same_type(t, u, nil))
+         return (same_type(t, u))
       end
 
       local function intersect_facts(fs: {Fact}, errnode: Node): boolean, Type
@@ -4747,7 +4839,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
       for _, f in ipairs(facts) do
          if f.fact == "is" then
-            local t = resolve_typevars(f.typ, {}) -- new type object
+            local t = resolve_typevars(f.typ) -- new type object
             t.inferred_at = where
             t.inferred_at_file = filename
             add_var(nil, f.var, t, nil, true)
@@ -4783,7 +4875,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   infertype = nil
                end
                if decltype and infertype then
-                  assert_is_a(node.vars[i], infertype, decltype, {}, "local declaration", var.tk)
+                  assert_is_a(node.vars[i], infertype, decltype, "local declaration", var.tk)
                end
                local t = decltype or infertype
                if t == nil then
@@ -4815,7 +4907,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   infertype = nil
                end
                if decltype and infertype then
-                  assert_is_a(node.vars[i], infertype, decltype, {}, "global declaration", var.tk)
+                  assert_is_a(node.vars[i], infertype, decltype, "global declaration", var.tk)
                end
                local t = decltype or infertype
                local existing, existing_is_const = find_global(var.tk)
@@ -4862,7 +4954,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                if vartype then
                   local val = exps[i]
                   if val then
-                     assert_is_a(varnode, val, vartype, {}, "assignment")
+                     assert_is_a(varnode, val, vartype, "assignment")
                      if varnode.kind == "variable" and vartype.typename == "union" then
                         -- narrow union
                         add_var(varnode, varnode.tk, val, false, true)
@@ -5034,7 +5126,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                node_error(node, "excess return values, expected " .. #rets .. " got " .. #children[1])
             end
             for i = 1, math.min(#children[1], #rets) do
-               assert_is_a(node.exps[i], children[1][i], rets[i], nil, "return value")
+               assert_is_a(node.exps[i], children[1][i], rets[i], "return value")
             end
 
             -- if at the toplevel
@@ -5121,7 +5213,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             local vtype = children[2]
             if node.decltype then
                vtype = node.decltype
-               assert_is_a(node.value, children[2], node.decltype, {}, "table item")
+               assert_is_a(node.value, children[2], node.decltype, "table item")
             end
             node.type = {
                y = node.y,
@@ -5250,8 +5342,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             if node.op.op == "@funcall" then
                if node.e1.tk == "rawget" then
                   if #b == 2 then
-                     local b1 = resolve_unary(b[1], {})
-                     local b2 = resolve_unary(b[2], {})
+                     local b1 = resolve_unary(b[1])
+                     local b2 = resolve_unary(b[2])
                      if b1.typename == "record" and node.e2[2].conststr then
                         node.type = match_record_key(node, b1, { kind = "string", tk = assert(node.e2[2].conststr) }, b1)
                      else
@@ -5316,7 +5408,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                end
                node.type = BOOLEAN
             elseif node.op.op == "." then
-               a = resolve_unary(a, {}) -- FIXME propagate typevars?
+               a = resolve_unary(a)
                if a.typename == "map" then
                   if is_a(a.keys, STRING) or is_a(a.keys, ANY) then
                      node.type = a.values
@@ -5356,7 +5448,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "==" or node.op.op == "~=" then
-               if is_a(a, b, {}, true) or is_a(b, a, {}, true) then
+               if is_a(a, b, true) or is_a(b, a, true) then
                   node.type = BOOLEAN
                else
                   if lax and (is_unknown(a) or is_unknown(b)) then

--- a/tl.tl
+++ b/tl.tl
@@ -4986,10 +4986,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             local exp1 = node.exps[1]
             local exp1type = resolve_tuple(exp1.type)
             if exp1type.typename == "function" then
-               add_var(node.vars[1], node.vars[1].tk, exp1type.rets[1])
-               if node.vars[2] then
-                  add_var(node.vars[2], node.vars[2].tk, exp1type.rets[2])
-               end
+               local r1 = exp1type.rets[1]
+               local r2 = exp1type.rets[2]
                -- check common errors:
                if exp1.op and exp1.op.op == "@funcall" then
                   local t = resolve_unary(exp1.e2.type)
@@ -4997,11 +4995,18 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                      if not (lax and is_unknown(t)) then
                         node_error(exp1, "attempting pairs loop on something that's not a map or record: %s", exp1.e2.type)
                      end
+                     r1 = UNKNOWN
+                     r2 = UNKNOWN
                   elseif exp1.e1.tk == "ipairs" and not (t.typename == "array" or t.typename == "arrayrecord") then
                      if not (lax and (is_unknown(t) or t.typename == "emptytable")) then
                         node_error(exp1, "attempting ipairs loop on something that's not an array: %s", exp1.e2.type)
                      end
+                     r2 = UNKNOWN
                   end
+               end
+               add_var(node.vars[1], node.vars[1].tk, r1)
+               if node.vars[2] then
+                  add_var(node.vars[2], node.vars[2].tk, r2)
                end
             else
                if not (lax and is_unknown(exp1type)) then
@@ -5257,6 +5262,9 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   else
                      node_error(node, "rawget expects two arguments")
                   end
+               elseif node.e1.tk == "print_type" then
+                  print(show_type(b))
+                  node.type = BOOLEAN
                elseif node.e1.tk == "require" then
                   if #b == 1 then
                      if node.e2[1].kind == "string" then

--- a/tl.tl
+++ b/tl.tl
@@ -702,6 +702,14 @@ local TypeName = enum
    "none"
 end
 
+local table_types: {TypeName:boolean} = {
+   ["array"] = true,
+   ["map"] = true,
+   ["arrayrecord"] = true,
+   ["record"] = true,
+   ["emptytable"] = true,
+}
+
 local Type = record
    {Type}
    y: number
@@ -1308,9 +1316,9 @@ do
          ["~"] = 11,
       },
       [2] = {
-         ["is"] = 0,
          ["or"] = 1,
          ["and"] = 2,
+         ["is"] = 3,
          ["<"] = 3,
          [">"] = 3,
          ["<="] = 3,
@@ -2000,7 +2008,7 @@ local function visit_after<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K, `N,`T
    return ret
 end
 
-local function recurse_type(ast: Type, visit: Visitor<TypeKind, Type, `T>): `T
+local function recurse_type<`T>(ast: Type, visit: Visitor<TypeKind, Type, `T>): `T
    visit_before(ast, ast.kind, visit)
    local xs: {`T} = {}
    if ast.kind == "type_list"
@@ -2044,6 +2052,9 @@ local function recurse_node<`T>(ast: Node,
       xs[1] = recurse_node(ast.vars, visit_node, visit_type)
       if ast.exps then
          xs[2] = recurse_node(ast.exps, visit_node, visit_type)
+      end
+      if ast.decltype then
+         xs[3] = recurse_type(ast.decltype, visit_type)
       end
    elseif ast.kind == "table_item" then
       xs[1] = recurse_node(ast.key, visit_node, visit_type)
@@ -2127,7 +2138,11 @@ local function recurse_node<`T>(ast: Node,
          if cbs.before_e2 then
             cbs.before_e2(ast, xs)
          end
-         xs[3] = recurse_node(ast.e2, visit_node, visit_type)
+         if ast.op.op == "is" then
+            xs[3] = recurse_type(ast.e2.casttype, visit_type)
+         else
+            xs[3] = recurse_node(ast.e2, visit_node, visit_type)
+         end
          xs[4] = (ast.e2.op and ast.e2.op.prec) as `T
       end
    elseif ast.kind == "newtype" then
@@ -2635,11 +2650,27 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
       },
    }
 
+   local primitive: {TypeName:string} = {
+      ["function"] = "function",
+      ["enum"] = "string",
+      ["boolean"] = "boolean",
+      ["string"] = "string",
+      ["nil"] = "nil",
+      ["number"] = "number",
+   }
+
    local visit_type: Visitor<TypeKind, Type, Output> = {}
    visit_type.cbs = {
       ["type_list"] = {
          after = function(typ: Type, children: {Output}): Output
             local out: Output = { y = typ.y, h = 0 }
+            return out
+         end,
+      },
+      ["typedecl"] = {
+         after = function(typ: Type, children: {Output}): Output
+            local out: Output = { y = typ.y, h = 0 }
+            table.insert(out, primitive[typ.typename] or "table")
             return out
          end,
       },
@@ -2655,8 +2686,6 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
    visit_node.cbs["boolean"] = visit_node.cbs["variable"]
    visit_node.cbs["..."] = visit_node.cbs["variable"]
    visit_node.cbs["argument"] = visit_node.cbs["variable"]
-
-   visit_type.cbs["typedecl"] = visit_type.cbs["type_list"]
 
    local out = recurse_node(ast, visit_node, visit_type)
    return concat_output(out)
@@ -5569,7 +5598,29 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   if not find_type(typ.names) then
                      type_error(typ, "unknown type %s", typ)
                   end
+               elseif typ.typename == "union" then
+                  -- check for limitations in our union support
+                  -- due to codegen limitations (we only check with type() so far)
+                  local n_table_types = 0
+                  local n_string_enum = 0
+                  for _, t in ipairs(typ.types) do
+                     t = resolve_unary(t)
+                     if table_types[t.typename] then
+                        n_table_types = n_table_types + 1
+                        if n_table_types > 1 then
+                           type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
+                           break
+                        end
+                     elseif t.typename == "string" or t.typename == "enum" then
+                        n_string_enum = n_string_enum + 1
+                        if n_string_enum > 1 then
+                           type_error(typ, "cannot discriminate a union between multiple string/enum types: %s", typ)
+                           break
+                        end
+                     end
+                  end
                end
+
                return typ
             end,
          },

--- a/tl.tl
+++ b/tl.tl
@@ -672,6 +672,7 @@ local TypeName = enum
    "string"
    "nil"
    "number"
+   "union"
    "nominal"
    "bad_nominal"
    "emptytable"
@@ -703,6 +704,9 @@ local Type = record
 
    -- poly
    poly: {Type}
+
+   -- union
+   types: {Type}
 
    -- typetype
    def: Type
@@ -800,6 +804,16 @@ local NodeKind = enum
    "paren"
 end
 
+local FactType = enum
+   "is"
+end
+
+local Fact = record
+   fact: FactType
+   var: string
+   typ: Type
+end
+
 local Node = record
    {Node}
    y: number
@@ -808,6 +822,8 @@ local Node = record
    kind: NodeKind
 
    yend: number
+
+   facts: {Fact}
 
    key: Node
    value: Node
@@ -1072,7 +1088,7 @@ local function parse_typeval_list(tokens: {Token}, i: number, errs: {ParseError}
    return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_type)
 end
 
-parse_type = function(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
+local function parse_base_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
    if tokens[i].tk == "string"
       or tokens[i].tk == "boolean"
       or tokens[i].tk == "nil"
@@ -1134,6 +1150,31 @@ parse_type = function(tokens: {Token}, i: number, errs: {ParseError}): number, T
       return i, typ
    end
    return fail(tokens, i, errs)
+end
+
+parse_type = function(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
+   local istart = i
+   local bt: Type
+   i, bt = parse_base_type(tokens, i, errs)
+   if not bt then
+      return i
+   end
+   if tokens[i].tk == "|" then
+      local u = new_type(tokens, istart, "typedecl")
+      u.typename = "union"
+      u.types = { bt }
+      while tokens[i].tk == "|" do
+         i = i + 1
+         i, bt = parse_base_type(tokens, i, errs)
+         if not bt then
+            return i
+         end
+         table.insert(u.types, bt)
+      end
+      return i, u
+   else
+      return i, bt
+   end
 end
 
 parse_type_list = function(tokens: {Token}, i: number, errs: {ParseError}, open: string): number, Type
@@ -1220,6 +1261,7 @@ do
          ["~"] = 11,
       },
       [2] = {
+         ["is"] = 0,
          ["or"] = 1,
          ["and"] = 2,
          ["<"] = 3,
@@ -1319,8 +1361,8 @@ do
             i, key = verify_kind(tokens, i, errs, "identifier")
 
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = key }
-         elseif tokens[i].tk == "as" then
-            local op: Operator = new_operator(tokens[i], 2, "as")
+         elseif tokens[i].tk == "as" or tokens[i].tk == "is" then
+            local op: Operator = new_operator(tokens[i], 2, tokens[i].tk)
 
             i = i + 1
             local cast = new_node(tokens, i, "cast")
@@ -2459,6 +2501,12 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
                table.insert(out, "]")
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
+            elseif node.op.op == "is" then
+               table.insert(out, "type(")
+               add_child(out, children[1], "", indent)
+               table.insert(out, ") == \"")
+               add_child(out, children[3], "", indent) -- FIXME table types should be "table"
+               table.insert(out, "\"")
             elseif spaced_op[node.op.arity][node.op.op] or tight_op[node.op.arity][node.op.op] then
                local space = spaced_op[node.op.arity][node.op.op] and " " or ""
                if children[2] and node.op.prec > tonumber(children[2]) then
@@ -2774,6 +2822,12 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
          table.insert(out, show_type(v))
       end
       return table.concat(out, " or ")
+   elseif t.typename == "union" then
+      local out: {string} = {}
+      for _, v in ipairs(t.types) do
+         table.insert(out, show_type(v))
+      end
+      return table.concat(out, " | ")
    elseif t.typename == "emptytable" then
       return "{}"
    elseif t.typename == "map" then
@@ -2902,6 +2956,8 @@ local Variable = record
    t: Type
    is_const: boolean
    needs_compat53: boolean
+   narrowed_from: Type
+   is_narrowed: boolean
 end
 
 local function fill_field_order(t: Type)
@@ -3612,7 +3668,25 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   local function same_type(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
+   local same_type: function(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
+
+   local function has_all_types_of(t1s: {Type}, t2s: {Type}, typevars: {string:Type}): boolean
+      for _, t1 in ipairs(t1s) do
+         local found = false
+         for _, t2 in ipairs(t2s) do
+            if same_type(t1, t2, typevars) then
+               found = true
+               break
+            end
+         end
+         if not found then
+            return false
+         end
+      end
+      return true
+   end
+
+   same_type = function(t1: Type, t2: Type, typevars: {string:Type}): boolean, {Error}
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
@@ -3627,6 +3701,13 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          return same_type(t1.elements, t2.elements)
       elseif t1.typename == "map" then
          return same_type(t1.keys, t2.keys) and same_type(t1.values, t2.values)
+      elseif t1.typename == "union" then
+         if  has_all_types_of(t1.types, t2.types, typevars)
+         and has_all_types_of(t2.types, t1.types, typevars) then
+            return true
+         else
+            return false, terr(t1, "got %s, expected %s", t1, t2)
+         end
       elseif t1.typename == "nominal" then
          return same_names(t1, t2)
       elseif t1.typename == "record" then
@@ -3718,6 +3799,18 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             end
          end
          return false, terr(t1, "no match with poly") -- don't expect these errors to show, should fix if they do
+      elseif t1.typename == "union" and t2.typename == "union" then
+         if has_all_types_of(t1.types, t2.types, typevars) then
+            return true
+         else
+            return false, terr(t1, "got %s, expected %s", t1, t2)
+         end
+      elseif t2.typename == "union" then
+         for _, t in ipairs(t2.types) do
+            if is_a(t1, t, typevars, for_equality) then
+               return true
+            end
+         end
       elseif t1.typename == "poly" then
          for _, t in ipairs(t1.poly) do
             if is_a(t, t2, typevars, for_equality) then
@@ -4083,11 +4176,55 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return node_error(node, "invalid key '" .. key.tk .. "' in " .. description)
    end
 
-   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean)
+   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean)
       if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
          add_unknown(node, var)
       end
-      st[#st][var] = { t = valtype, is_const = is_const }
+      if st[#st][var] and is_narrowing then
+         if not st[#st][var].is_narrowed then
+            st[#st][var].narrowed_from = st[#st][var].t
+         end
+         st[#st][var].is_narrowed = true
+         st[#st][var].t = valtype
+      else
+         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing }
+      end
+   end
+
+   local function widen_in_scope(scope: {string:Variable}, var: string): boolean
+      if scope[var].is_narrowed then
+         if scope[var].narrowed_from then
+            scope[var].t = scope[var].narrowed_from
+            scope[var].narrowed_from = nil
+            scope[var].is_narrowed = false
+         else
+            scope[var] = nil
+         end
+         return true
+      end
+      return false
+   end
+
+   local function widen_back_var(var: string): boolean
+      local widened = false
+      for i = #st, 1, -1 do
+         if st[i][var] then
+            if widen_in_scope(st[i], var) then
+               widened = true
+            else
+               break
+            end
+         end
+      end
+      return widened
+   end
+
+   local function widen_all_unions()
+      for i = #st, 1, -1 do
+         for var, _ in pairs(st[i]) do
+            widen_in_scope(st[i], var)
+         end
+      end
    end
 
    local function add_global(node: Node, var: string, valtype: Type, is_const: boolean)
@@ -4300,6 +4437,218 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
+   local facts_and: function(f1: {Fact}, f2: {Fact}, errnode: Node): {Fact}
+   local facts_or:  function(f1: {Fact}, f2: {Fact}): {Fact}
+   local facts_not: function(f1: {Fact}): {Fact}
+   do
+      local function join_facts(fss: {{Fact}}): {string:{Fact}}
+         local vars: {string:{Fact}} = {}
+
+         for _, fs in ipairs(fss) do
+            for _, f in ipairs(fs) do
+               if not vars[f.var] then
+                  vars[f.var] = {}
+               end
+               table.insert(vars[f.var], f)
+            end
+         end
+         return vars
+      end
+
+      local function intersect(xs: {`T}, ys: {`T}, same: function(`T, `T): boolean): {`T}
+         local rs = {}
+         for i = #xs, 1, -1 do
+            local x = xs[i]
+            for _, y in ipairs(ys) do
+               if same(x, y) then
+                  table.insert(rs, x)
+                  break
+               end
+            end
+         end
+         return rs
+      end
+
+      local function same_type_for_intersect(t: Type, u: Type): boolean
+         return (same_type(t, u, nil))
+      end
+
+      local function intersect_facts(fs: {Fact}, errnode: Node): boolean, Type
+         local all_is = true
+         local types = {}
+         for i, f in ipairs(fs) do
+            if f.fact ~= "is" then
+               all_is = false
+               break
+            end
+            if f.typ.typename == "union" then
+               if i == 1 then
+                  types = f.typ.types
+               else
+                  types = intersect(types, f.typ.types, same_type_for_intersect)
+               end
+            else
+               if i == 1 then
+                  types = { f.typ }
+               else
+                  types = intersect(types, { f.typ }, same_type_for_intersect)
+               end
+            end
+         end
+
+         if #types == 0 then
+            node_error(errnode, "branch is always false")
+            return false
+         end
+
+         if all_is then
+            if #types == 1 then
+               return true, types[1]
+            else
+               return true, {
+                  typeid = new_typeid(),
+                  typename = "union",
+                  types = types,
+               }
+            end
+         else
+            return false
+         end
+      end
+
+      local function sum_facts(fs: {Fact}): boolean, Type
+         local all_is = true
+         local types: {Type} = {}
+         for _, f in ipairs(fs) do
+            if f.fact ~= "is" then
+               all_is = false
+               break
+            end
+            table.insert(types, f.typ)
+         end
+
+         if all_is then
+            if #types == 1 then
+               return true, types[1]
+            else
+               return true, {
+                  typeid = new_typeid(),
+                  typename = "union",
+                  types = types,
+               }
+            end
+         else
+            return false
+         end
+      end
+
+      local function subtract_types(u1: Type, u2: Type, errt: Type): Type
+         local types: {Type} = {}
+         for _, rt in ipairs(u1.types or { u1 }) do
+            local not_present = true
+            for _, ft in ipairs(u2.types or { u2 }) do
+               if same_type(rt, ft) then
+                  not_present = false
+                  break
+               end
+            end
+            if not_present then
+               table.insert(types, rt)
+            end
+         end
+
+         if #types == 0 then
+            type_error(errt, "branch is always false")
+            return INVALID
+         end
+
+         if #types == 1 then
+            return types[1]
+         else
+            return {
+               typeid = new_typeid(),
+               typename = "union",
+               types = types,
+            }
+         end
+      end
+
+      facts_and = function(f1: {Fact}, f2: {Fact}, errnode: Node): {Fact}
+         if not f1 then
+            return f2
+         end
+         if not f2 then
+            return f1
+         end
+
+         local out: {Fact} = {}
+         for v, fs in pairs(join_facts({f1, f2})) do
+            local ok, u = intersect_facts(fs, errnode)
+
+            if ok then
+               table.insert(out, { fact = "is", var = v, typ = u })
+            else
+               -- FIXME handle non-"is" facts... when we have them
+               for _, f in ipairs(fs) do
+                  table.insert(out, f)
+               end
+            end
+         end
+         return out
+      end
+
+      facts_or = function(f1: {Fact}, f2: {Fact}): {Fact}
+         if not f1 or not f2 then
+            return nil
+         end
+
+         local out: {Fact} = {}
+         for v, fs in pairs(join_facts({f1, f2})) do
+            local ok, u = sum_facts(fs)
+            if ok then
+               table.insert(out, { fact = "is", var = v, typ = u })
+            else
+               -- FIXME handle non-"is" facts... when we have them
+               for _, f in ipairs(fs) do
+                  table.insert(out, f)
+               end
+            end
+         end
+         return out
+      end
+
+      facts_not = function(f1: {Fact}): {Fact}
+         if not f1 then
+            return nil
+         end
+
+         local out: {Fact} = {}
+         for v, fs in pairs(join_facts({f1})) do
+            local realtype = find_var(v)
+            local ok, u = sum_facts(fs) -- is this correct?
+            if ok then
+               local not_typ = subtract_types(realtype, u, fs[1].typ)
+               table.insert(out, { fact = "is", var = v, typ = not_typ })
+            end
+         end
+         return out
+      end
+   end
+
+   local function apply_facts(where: Node, facts: {Fact})
+      if not facts then
+         return
+      end
+      for _, f in ipairs(facts) do
+         if f.fact == "is" then
+            local t = resolve_typevars(f.typ, {}) -- new type object
+            t.inferred_at = where
+            t.inferred_at_file = filename
+            add_var(nil, f.var, t, nil, true)
+         end
+      end
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -4339,6 +4688,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   t.declared_at = node
                   t.assigned_to = var.tk
                end
+               assert(var)
                add_var(var, var.tk, t, var.is_const)
             end
             node.type = { typeid = new_typeid(), typename = "none" }
@@ -4393,10 +4743,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                if varnode.is_const then
                   node_error(varnode, "cannot assign to <const> variable")
                end
+               if varnode.kind == "variable" then
+                  if widen_back_var(varnode.tk) then
+                     vartype = find_var(varnode.tk)
+                  end
+               end
                if vartype then
                   local val = exps[i]
                   if val then
                      assert_is_a(varnode, val, vartype, {}, "assignment")
+                     if varnode.kind == "variable" and vartype.typename == "union" then
+                        -- narrow union
+                        add_var(varnode, varnode.tk, val, false, true)
+                     end
                   else
                      node_error(varnode, "variable is not being assigned a value")
                   end
@@ -4407,7 +4766,71 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
       },
+      ["do"] = {
+         after = function(node: Node, children: {Type}): Type
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
       ["if"] = {
+         before_statements = function(node: Node)
+            table.insert(st, {})
+            apply_facts(node.exp, node.exp.facts)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            table.remove(st)
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
+      ["elseif"] = {
+         before = function(node: Node)
+            table.remove(st)
+            table.insert(st, {})
+         end,
+         before_statements = function(node: Node)
+            local f = facts_not(node.parent_if.exp.facts)
+            for e = 1, node.elseif_n - 1 do
+               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.facts), node)
+            end
+            f = facts_and(f, node.exp.facts, node)
+            apply_facts(node.exp, f)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
+      ["else"] = {
+         before = function(node: Node)
+            table.remove(st)
+            table.insert(st, {})
+            local f = facts_not(node.parent_if.exp.facts)
+            for _, elseifnode in ipairs(node.parent_if.elseifs) do
+               f = facts_and(f, facts_not(elseifnode.exp.facts), node)
+            end
+            apply_facts(node, f)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
+      ["while"] = {
+         before = function()
+            -- widen all narrowed variables because we don't calculate a fixpoint yet
+            widen_all_unions()
+         end,
+         before_statements = function(node: Node)
+            table.insert(st, {})
+            apply_facts(node.exp, node.exp.facts)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            table.remove(st)
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
+      ["repeat"] = {
+         before = function()
+            -- widen all narrowed variables because we don't calculate a fixpoint yet
+            widen_all_unions()
+         end,
          after = function(node: Node, children: {Type}): Type
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
@@ -4736,6 +5159,13 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                node.type = type_check_index(node, node.e2, a, b)
             elseif node.op.op == "as" then
                node.type = b
+            elseif node.op.op == "is" then
+               if node.e1.kind == "variable" then
+                  node.facts = { { fact = "is", var = node.e1.tk, typ = b } }
+               else
+                  node_error(node, "can only use 'is' on variables")
+               end
+               node.type = BOOLEAN
             elseif node.op.op == "." then
                a = resolve_unary(a, {}) -- FIXME propagate typevars?
                if a.typename == "map" then
@@ -4756,19 +5186,25 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             elseif node.op.op == ":" then
                node.type = match_record_key(node, node.e1.type, node.e2, orig_a)
             elseif node.op.op == "not" then
+               node.facts = facts_not(node.e1.facts)
                node.type = BOOLEAN
             elseif node.op.op == "and" then
+               node.facts = facts_and(node.e1.facts, node.e2.facts, node)
                node.type = resolve_tuple(b)
             elseif node.op.op == "or" and b.typename == "emptytable" then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and same_type(resolve_unary(a), resolve_unary(b)) then
+               node.facts = facts_or(node.e1.facts, node.e2.facts)
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and b.typename == "nil" then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or"
                    and (a.typename == "nominal" or a.typename == "map")
                    and (b.typename == "record" or b.typename == "arrayrecord")
                    and is_a(b, a) then
+               node.facts = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "==" or node.op.op == "~=" then
                if is_a(a, b, {}, true) or is_a(b, a, {}, true) then
@@ -4792,6 +5228,10 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   end
                end
             elseif node.op.arity == 2 and binop_types[node.op.op] then
+               if node.op.op == "or" then
+                  node.facts = facts_or(node.e1.facts, node.e2.facts)
+               end
+
                a = resolve_unary(a)
                b = resolve_unary(b)
                local types_op = binop_types[node.op.op]
@@ -4833,12 +5273,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       }
    }
 
-   visit_node.cbs["while"] = visit_node.cbs["if"]
-   visit_node.cbs["repeat"] = visit_node.cbs["if"]
-   visit_node.cbs["do"] = visit_node.cbs["if"]
-   visit_node.cbs["break"] = visit_node.cbs["if"]
-   visit_node.cbs["elseif"] = visit_node.cbs["if"]
-   visit_node.cbs["else"] = visit_node.cbs["if"]
+   visit_node.cbs["break"] = visit_node.cbs["do"]
 
    visit_node.cbs["values"] = visit_node.cbs["variables"]
    visit_node.cbs["expression_list"] = visit_node.cbs["variables"]

--- a/tl.tl
+++ b/tl.tl
@@ -58,6 +58,7 @@ local TokenKind = enum
    "op"
    "string"
    "[" "]" "(" ")" "{" "}" "," ":" "#" "`" "." ";"
+   "::"
    "..."
    "identifier"
    "number"
@@ -116,7 +117,7 @@ for c = string.byte("A"), string.byte("F") do
 end
 
 local lex_char_symbols: {string:boolean} = {}
-for _, c in ipairs({"[", "]", "(", ")", "{", "}", ",", ":", "#", "`", ";"}) do
+for _, c in ipairs({"[", "]", "(", ")", "{", "}", ",", "#", "`", ";"}) do
    lex_char_symbols[c] = true
 end
 
@@ -147,6 +148,7 @@ local LexState = enum
    "hex_float"
    "lt"
    "gt"
+   "colon"
    "maybeequals"
    "maybelongstring"
    "dblquote_string"
@@ -266,6 +268,9 @@ function tl.lex(input: string): {Token}, {Token}
          elseif c == "<" then
             state = "lt"
             begin_token()
+         elseif c == ":" then
+            state = "colon"
+            begin_token()
          elseif c == ">" then
             state = "gt"
             begin_token()
@@ -364,6 +369,15 @@ function tl.lex(input: string): {Token}, {Token}
             state = "any"
          else
             end_token("op", i - 1)
+            fwd = false
+            state = "any"
+         end
+      elseif state == "colon" then
+         if c == ":" then
+            end_token("::")
+            state = "any"
+         else
+            end_token(":", i - 1)
             fwd = false
             state = "any"
          end
@@ -683,6 +697,7 @@ local TypeName = enum
    "any"
    "unknown"
    "invalid"
+   "unresolved_labels"
    "none"
 end
 
@@ -754,6 +769,9 @@ local Type = record
 
    -- enum
    enumset: {string:boolean}
+
+   -- goto label checks
+   labels: {string:{Node}}
 end
 
 local Operator = record
@@ -781,6 +799,8 @@ local NodeKind = enum
    "while"
    "fornum"
    "forin"
+   "goto"
+   "label"
    "repeat"
    "do"
    "break"
@@ -866,6 +886,9 @@ local Node = record
    e2: Node
    constnum: number
    conststr: string
+
+   -- goto
+   label: string
 
    casttype: Type
 
@@ -1640,6 +1663,23 @@ local function parse_break(tokens: {Token}, i: number, errs: {ParseError}): numb
    return i, node
 end
 
+local function parse_goto(tokens: {Token}, i: number, errs: {ParseError}): number, Node
+   local node = new_node(tokens, i, "goto")
+   i = verify_tk(tokens, i, errs, "goto")
+   node.label = tokens[i].tk
+   i = verify_kind(tokens, i, errs, "identifier")
+   return i, node
+end
+
+local function parse_label(tokens: {Token}, i: number, errs: {ParseError}): number, Node
+   local node = new_node(tokens, i, "label")
+   i = verify_tk(tokens, i, errs, "::")
+   node.label = tokens[i].tk
+   i = verify_kind(tokens, i, errs, "identifier")
+   i = verify_tk(tokens, i, errs, "::")
+   return i, node
+end
+
 local stop_statement_list: {string:boolean} = {
    ["end"] = true,
    ["else"] = true,
@@ -1861,6 +1901,10 @@ local function parse_statement(tokens: {Token}, i: number, errs: {ParseError}): 
       return parse_break(tokens, i, errs)
    elseif tokens[i].tk == "return" then
       return parse_return(tokens, i, errs)
+   elseif tokens[i].tk == "goto" then
+      return parse_goto(tokens, i, errs)
+   elseif tokens[i].tk == "::" then
+      return parse_label(tokens, i, errs)
    else
       return parse_call_or_assignment(tokens, i, errs)
    end
@@ -2072,6 +2116,8 @@ local function recurse_node(ast: Node,
           or ast.kind == "string"
           or ast.kind == "number"
           or ast.kind == "break"
+          or ast.kind == "goto"
+          or ast.kind == "label"
           or ast.kind == "nil"
           or ast.kind == "..."
           or ast.kind == "boolean" then
@@ -2545,6 +2591,23 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
          after = function(node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "{}")
+            return out
+         end,
+      },
+      ["goto"] = {
+         after = function(node: Node, children: {Output}): Output
+            local out: Output = { y = node.y, h = 0 }
+            table.insert(out, "goto ")
+            table.insert(out, node.label)
+            return out
+         end,
+      },
+      ["label"] = {
+         after = function(node: Node, children: {Output}): Output
+            local out: Output = { y = node.y, h = 0 }
+            table.insert(out, "::")
+            table.insert(out, node.label)
+            table.insert(out, "::")
             return out
          end,
       },
@@ -4234,8 +4297,30 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       st[1][var] = { t = valtype, is_const = is_const }
    end
 
-   local function begin_function_scope(node: Node, recurse: boolean)
+   local function begin_scope()
       table.insert(st, {})
+   end
+
+   local function end_scope()
+      local unresolved = st[#st]["@unresolved"]
+      if unresolved then
+         local upper = st[#st - 1]["@unresolved"]
+         if upper then
+            for name, nodes in pairs(unresolved.t.labels) do
+               for _, node in ipairs(nodes) do
+                  upper.t.labels[name] = upper.t.labels[name] or {}
+                  table.insert(upper.t.labels[name], node)
+               end
+            end
+         else
+            st[#st - 1]["@unresolved"] = unresolved
+         end
+      end
+      table.remove(st)
+   end
+
+   local function begin_function_scope(node: Node, recurse: boolean)
+      begin_scope()
       local args = {}
       for i, arg in ipairs(node.args) do
          local t = arg.decltype
@@ -4262,8 +4347,21 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
+   local function fail_unresolved_labels()
+      local unresolved = st[#st]["@unresolved"]
+      if unresolved then
+         st[#st]["@unresolved"] = nil
+         for name, nodes in pairs(unresolved.t.labels) do
+            for _, node in ipairs(nodes) do
+               node_error(node, "no visible label '" .. name .. "' for goto")
+            end
+         end
+      end
+   end
+
    local function end_function_scope()
-      table.remove(st)
+      fail_unresolved_labels()
+      end_scope()
    end
 
    local function flatten_list(list: {Type}): {Type}
@@ -4654,10 +4752,15 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
    visit_node.cbs = {
       ["statements"] = {
          before = function()
-            table.insert(st, {})
+            begin_scope()
          end,
          after = function(node: Node, children: {Type}): Type
-            table.remove(st)
+            -- if at the top level
+            if #st == 2 then
+               fail_unresolved_labels()
+            end
+
+            end_scope()
             -- TODO extract node type from `return`
             node.type = { typeid = new_typeid(), typename = "none" }
          end
@@ -4773,18 +4876,18 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       },
       ["if"] = {
          before_statements = function(node: Node)
-            table.insert(st, {})
+            begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
          after = function(node: Node, children: {Type}): Type
-            table.remove(st)
+            end_scope()
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
       },
       ["elseif"] = {
          before = function(node: Node)
-            table.remove(st)
-            table.insert(st, {})
+            end_scope()
+            begin_scope()
          end,
          before_statements = function(node: Node)
             local f = facts_not(node.parent_if.exp.facts)
@@ -4800,8 +4903,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       },
       ["else"] = {
          before = function(node: Node)
-            table.remove(st)
-            table.insert(st, {})
+            end_scope()
+            begin_scope()
             local f = facts_not(node.parent_if.exp.facts)
             for _, elseifnode in ipairs(node.parent_if.elseifs) do
                f = facts_and(f, facts_not(elseifnode.exp.facts), node)
@@ -4818,11 +4921,41 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             widen_all_unions()
          end,
          before_statements = function(node: Node)
-            table.insert(st, {})
+            begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
          after = function(node: Node, children: {Type}): Type
-            table.remove(st)
+            end_scope()
+            node.type = { typeid = new_typeid(), typename = "none" }
+         end,
+      },
+      ["label"] = {
+         before = function(node: Node)
+            -- widen all narrowed variables because we don't calculate a fixpoint yet
+            widen_all_unions()
+            local label_id = "::" .. node.label .. "::"
+            if st[#st][label_id] then
+               node_error(node, "label '" .. node.label .. "' already defined at " .. filename )
+            end
+            local unresolved = st[#st]["@unresolved"]
+            if unresolved then
+               unresolved.t.labels[node.label] = nil
+            end
+            node.type = { y = node.y, x = node.x, typeid = new_typeid(), typename = "none", }
+            add_var(node, label_id, node.type)
+         end,
+      },
+      ["goto"] = {
+         after = function(node: Node, children: {Type}): Type
+            if not find_var("::" .. node.label .. "::") then
+               local unresolved = find_var("@unresolved")
+               if not unresolved then
+                  unresolved = { typename = "unresolved_labels", labels = {} }
+                  add_var(node, "@unresolved", unresolved)
+               end
+               unresolved.labels[node.label] = unresolved.labels[node.label] or {}
+               table.insert(unresolved.labels[node.label], node)
+            end
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
       },
@@ -4837,7 +4970,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       },
       ["forin"] = {
          before = function()
-            table.insert(st, {})
+            begin_scope()
          end,
          before_statements = function(node: Node)
             local exp1 = node.exps[1]
@@ -4867,17 +5000,17 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             end
          end,
          after = function(node: Node, children: {Type}): Type
-            table.remove(st)
+            end_scope()
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
       },
       ["fornum"] = {
          before = function(node: Node)
-            table.insert(st, {})
+            begin_scope()
             add_var(nil, node.var.tk, NUMBER)
          end,
          after = function(node: Node, children: {Type}): Type
-            table.remove(st)
+            end_scope()
             node.type = { typeid = new_typeid(), typename = "none" }
          end,
       },

--- a/tl.tl
+++ b/tl.tl
@@ -2854,9 +2854,19 @@ local function is_unknown(t: Type): boolean
        or t.typename == "unknown_emptytable_value"
 end
 
-local show_type: function(Type, {string:Type}): string
+local show_type: function(Type, {string:Type}, {Type:boolean}): string
 
-local function show_type_base(t: Type, typevars: {string:Type}): string
+local function show_type_base(t: Type, typevars: {string:Type}, seen: {Type:boolean}): string
+   -- FIXME this is a control for recursively built types, which should in principle not exist
+   if seen[t] then
+      return "..."
+   end
+   seen[t] = true
+
+   local function show(t: Type): string
+      return show_type(t, typevars, seen)
+   end
+
    if typevars then
       t = resolve_typevars(t, typevars)
    end
@@ -2865,7 +2875,7 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
          local out = { table.concat(t.names, "."), "<" }
          local vals: {string} = {}
          for _, v in ipairs(t.typevals) do
-            table.insert(vals, show_type(v))
+            table.insert(vals, show(v))
          end
          table.insert(out, table.concat(vals, ", "))
          table.insert(out, ">")
@@ -2876,34 +2886,34 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
    elseif t.typename == "tuple" then
       local out: {string} = {}
       for _, v in ipairs(t) do
-         table.insert(out, show_type(v))
+         table.insert(out, show(v))
       end
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "poly" then
       local out: {string} = {}
       for _, v in ipairs(t.poly) do
-         table.insert(out, show_type(v))
+         table.insert(out, show(v))
       end
       return table.concat(out, " or ")
    elseif t.typename == "union" then
       local out: {string} = {}
       for _, v in ipairs(t.types) do
-         table.insert(out, show_type(v))
+         table.insert(out, show(v))
       end
       return table.concat(out, " | ")
    elseif t.typename == "emptytable" then
       return "{}"
    elseif t.typename == "map" then
-      return "{" .. show_type(t.keys) .. " : " .. show_type(t.values) .. "}"
+      return "{" .. show(t.keys) .. " : " .. show(t.values) .. "}"
    elseif t.typename == "array" then
-      return "{" .. show_type(t.elements) .. "}"
+      return "{" .. show(t.elements) .. "}"
    elseif t.typename == "enum" then
-      return table.concat(t.names, ".")
+      return t.names and table.concat(t.names, ".") or "enum"
    elseif t.typename == "record" then
       local out: {string} = {}
       for _, k in ipairs(t.field_order) do
          local v = t.fields[k]
-         table.insert(out, k .. ": " .. show_type(v))
+         table.insert(out, k .. ": " .. show(v))
       end
       return "{" .. table.concat(out, ", ") .. "}"
    elseif t.typename == "function" then
@@ -2915,7 +2925,7 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
       end
       for i, v in ipairs(t.args) do
          if not t.is_method or i > 1 then
-            table.insert(args, show_type(v))
+            table.insert(args, show(v))
          end
       end
       table.insert(out, table.concat(args, ","))
@@ -2924,7 +2934,7 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
          table.insert(out, ":")
          local rets = {}
          for _, v in ipairs(t.rets) do
-            table.insert(rets, show_type(v))
+            table.insert(rets, show(v))
          end
          table.insert(out, table.concat(rets, ","))
       end
@@ -2946,7 +2956,7 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
    elseif t.typename == "nil" then
       return "nil"
    elseif t.typename == "typetype" then
-      return "type " .. show_type(t.def)
+      return "type " .. show(t.def)
    elseif t.typename == "bad_nominal" then
       return table.concat(t.names, ".") .. " (an unknown type)"
    else
@@ -2954,8 +2964,8 @@ local function show_type_base(t: Type, typevars: {string:Type}): string
    end
 end
 
-show_type = function(t: Type, typevars: {string:Type}): string
-   local ret = show_type_base(t, typevars)
+show_type = function(t: Type, typevars: {string:Type}, seen: {Type:boolean}): string
+   local ret = show_type_base(t, typevars, seen or {})
    if t.inferred_at then
       ret = ret .. " (inferred at "..t.inferred_at_file..":"..t.inferred_at.y..":"..t.inferred_at.x..": )"
    end

--- a/tl.tl
+++ b/tl.tl
@@ -1970,6 +1970,7 @@ end
 local VisitorCallbacks = record<`N, `T>
    before: function(`N, {`T})
    before_statements: function({`N}, {`T})
+   before_e2: function({`N}, {`T})
    after: function(`N, {`T}, `T): `T
 end
 
@@ -2123,6 +2124,9 @@ local function recurse_node<`T>(ast: Node,
       end
       xs[2] = p1 as `T
       if ast.op.arity == 2 then
+         if cbs.before_e2 then
+            cbs.before_e2(ast, xs)
+         end
          xs[3] = recurse_node(ast.e2, visit_node, visit_type)
          xs[4] = (ast.e2.op and ast.e2.op.prec) as `T
       end
@@ -5334,7 +5338,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end,
       },
       ["op"] = {
+         before = function(node: Node)
+            begin_scope()
+         end,
+         before_e2 = function(node: Node)
+            if node.op.op == "and" then
+               apply_facts(node, node.e1.facts)
+            elseif node.op.op == "or" then
+               apply_facts(node, facts_not(node.e1.facts))
+            end
+         end,
          after = function(node: Node, children: {Type}): Type
+            end_scope()
+
             local a: Type = children[1]
             local b: Type = children[3]
             local orig_a = a

--- a/tl.tl
+++ b/tl.tl
@@ -848,6 +848,7 @@ local Node = record
    key: Node
    value: Node
 
+   typevars: Type
    args: Node
    rets: Type
    body: Node
@@ -1067,29 +1068,8 @@ local function parse_trying_list(tokens: {Token}, i: number, errs: {ParseError},
    return i, list
 end
 
-local function parse_function_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type
-   i = i + 1
-   local node: Type = {
-      typeid = new_typeid(),
-      y = tokens[i - 1].y,
-      x = tokens[i - 1].x,
-      kind = "typedecl",
-      typename = "function",
-      args = {},
-      rets = {},
-   }
-   if tokens[i].tk == "(" then
-      i, node.args = parse_argument_type_list(tokens, i, errs)
-      i, node.rets = parse_type_list(tokens, i, errs)
-   else
-      node.args = { { typeid = new_typeid(), typename = "any", is_va = true } }
-      node.rets = { { typeid = new_typeid(), typename = "any", is_va = true } }
-   end
-   return i, node
-end
-
 local function parse_typevar_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
-   i = i + 1
+   i = verify_tk(tokens, i, errs, "`")
    i = verify_kind(tokens, i, errs, "identifier")
    return i, {
       typeid = new_typeid(),
@@ -1109,6 +1089,29 @@ end
 local function parse_typeval_list(tokens: {Token}, i: number, errs: {ParseError}): number, Type
    local typ = new_type(tokens, i, "typeval_list")
    return parse_bracket_list(tokens, i, errs, typ, "<", ">", "sep", parse_type)
+end
+
+local function parse_function_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type
+   i = i + 1
+   local node: Type = {
+      y = tokens[i - 1].y,
+      x = tokens[i - 1].x,
+      kind = "typedecl",
+      typename = "function",
+      args = {},
+      rets = {},
+   }
+   if tokens[i].tk == "<" then
+      i, node.typevars = parse_typevar_list(tokens, i, errs)
+   end
+   if tokens[i].tk == "(" then
+      i, node.args = parse_argument_type_list(tokens, i, errs)
+      i, node.rets = parse_type_list(tokens, i, errs)
+   else
+      node.args = { { typename = "any", is_va = true } }
+      node.rets = { { typename = "any", is_va = true } }
+   end
+   return i, node
 end
 
 local function parse_base_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
@@ -1220,6 +1223,9 @@ parse_type_list = function(tokens: {Token}, i: number, errs: {ParseError}, open:
 end
 
 local function parse_function_args_rets_body(tokens: {Token}, i: number, errs: {ParseError}, node: Node): number, Node
+   if tokens[i].tk == "<" then
+      i, node.typevars = parse_typevar_list(tokens, i, errs)
+   end
    i, node.args = parse_argument_list(tokens, i, errs)
    i, node.rets = parse_type_list(tokens, i, errs)
    i, node.body = parse_statements(tokens, i, errs)
@@ -1788,16 +1794,7 @@ parse_newtype = function(tokens: {Token}, i: number, errs: {ParseError}): number
       i = verify_tk(tokens, i, errs, "end")
       return i, node
    elseif tokens[i].tk == "functiontype" then
-      local typevars: Type
-      i = i + 1
-      if tokens[i].tk == "<" then
-         i, typevars = parse_typevar_list(tokens, i, errs)
-      end
-      i = i - 1
       i, node.newtype.def = parse_function_type(tokens, i, errs)
-      if typevars then
-         node.newtype.def.typevars = typevars
-      end
       return i, node
    end
    return fail(tokens, i, errs)
@@ -3075,24 +3072,24 @@ local standard_library: {string:Type} = {
    ["any"] = { typeid = new_typeid(), typename = "typetype", def = ANY },
    ["arg"] = ARRAY_OF_STRING,
    ["require"] = { typeid = new_typeid(), typename = "function", args = { STRING }, rets = {} },
-   ["setmetatable"] = { typeid = new_typeid(), typename = "function", args = { ALPHA, METATABLE }, rets = { ALPHA } },
+   ["setmetatable"] = { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ALPHA, METATABLE }, rets = { ALPHA } },
    ["getmetatable"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = { METATABLE } },
    ["rawget"] = { typeid = new_typeid(), typename = "function", args = { TABLE, ANY }, rets = { ANY } },
    ["rawset"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA, BETA }, rets = {} },
-         { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
+         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA, BETA }, rets = {} },
+         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
          { typeid = new_typeid(), typename = "function", args = { TABLE, ANY, ANY }, rets = {} },
       }
    },
    ["next"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", args = { MAP_OF_ALPHA_TO_BETA }, rets = { ALPHA, BETA } },
-         { typeid = new_typeid(), typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA }, rets = { ALPHA, BETA } },
-         { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA }, rets = { NUMBER, ALPHA } },
-         { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, ALPHA }, rets = { NUMBER, ALPHA } },
+         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA }, rets = { ALPHA, BETA } },
+         { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { MAP_OF_ALPHA_TO_BETA, ALPHA }, rets = { ALPHA, BETA } },
+         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA }, rets = { NUMBER, ALPHA } },
+         { typeid = new_typeid(), typevars = { ALPHA }, typename = "function", args = { ARRAY_OF_ALPHA, ALPHA }, rets = { NUMBER, ALPHA } },
       },
    },
    ["load"] = {
@@ -3133,7 +3130,7 @@ local standard_library: {string:Type} = {
             ["__call"] = FUNCTION,
             ["__gc"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = {} },
             ["__len"] = { typeid = new_typeid(), typename = "function", args = { ANY }, rets = { NUMBER } },
-            ["__pairs"] = { typeid = new_typeid(), typename = "function", args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
+            ["__pairs"] = { typeid = new_typeid(), typevars = { ALPHA, BETA }, typename = "function", args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
                   { typeid = new_typeid(), typename = "function", args = {}, rets = { ALPHA, BETA } },
             } },
             -- TODO complete...
@@ -3196,28 +3193,29 @@ local standard_library: {string:Type} = {
          ["unpack"] = {
             typeid = new_typeid(), typename = "function",
             needs_compat53 = true,
+            typevars = { ALPHA },
             args = { ARRAY_OF_ALPHA, NUMBER, NUMBER },
             rets = { { typeid = new_typeid(), typename = "typevar", typevar = "`a", is_va = true }
          } },
          ["move"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER }, rets = { ARRAY_OF_ALPHA } },
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER, ARRAY_OF_ALPHA }, rets = { ARRAY_OF_ALPHA } },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER }, rets = { ARRAY_OF_ALPHA } },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER, NUMBER, ARRAY_OF_ALPHA }, rets = { ARRAY_OF_ALPHA } },
             }
          },
          ["insert"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, ALPHA }, rets = {} },
             }
          },
          ["remove"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, NUMBER }, rets = { ALPHA } },
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA }, rets = { ALPHA } },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER }, rets = { ALPHA } },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = { ALPHA } },
             }
          },
          ["concat"] = {
@@ -3230,8 +3228,8 @@ local standard_library: {string:Type} = {
          ["sort"] = {
             typeid = new_typeid(), typename = "poly",
             poly = {
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA }, rets = {} },
-               { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA, { typeid = new_typeid(), typename = "function", args = { ALPHA, ALPHA }, rets = { BOOLEAN } } }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {} },
+               { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA, { typeid = new_typeid(), typename = "function", args = { ALPHA, ALPHA }, rets = { BOOLEAN } } }, rets = {} },
             }
          }
       },
@@ -3296,24 +3294,24 @@ local standard_library: {string:Type} = {
          ["offset"] = { typeid = new_typeid(), typename = "function", args = { STRING, NUMBER, NUMBER }, rets = { NUMBER } },
       },
    },
-   ["ipairs"] = { typeid = new_typeid(), typename = "function", args = { ARRAY_OF_ALPHA }, rets = {
+   ["ipairs"] = { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {
       { typeid = new_typeid(), typename = "function", args = {}, rets = { NUMBER, ALPHA } },
    } },
-   ["pairs"] = { typeid = new_typeid(), typename = "function", args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
+   ["pairs"] = { typeid = new_typeid(), typename = "function", typevars = { ALPHA, BETA }, args = { { typeid = new_typeid(), typename = "map", keys = ALPHA, values = BETA } }, rets = {
       { typeid = new_typeid(), typename = "function", args = {}, rets = { ALPHA, BETA } },
    } },
    ["pcall"] = { typeid = new_typeid(), typename = "function", args = { VARARG_ANY }, rets = { BOOLEAN, ANY } },
    ["assert"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", args = { ALPHA }, rets = { ALPHA } },
-         { typeid = new_typeid(), typename = "function", args = { ALPHA, BETA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { ALPHA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typevars = { ALPHA, BETA }, args = { ALPHA, BETA }, rets = { ALPHA } },
       }
    },
    ["select"] = {
       typeid = new_typeid(), typename = "poly",
       poly = {
-         { typeid = new_typeid(), typename = "function", args = { NUMBER, ALPHA }, rets = { ALPHA } },
+         { typeid = new_typeid(), typename = "function", typevars = { ALPHA }, args = { NUMBER, ALPHA }, rets = { ALPHA } },
          { typeid = new_typeid(), typename = "function", args = { STRING, VARARG_ANY }, rets = { NUMBER } },
       }
    },
@@ -3524,7 +3522,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return t
    end
 
-   local function error_in_type(t: Type, msg: string, ...:Type): Error
+   local function error_in_type(where: Type, msg: string, ...: Type): Error
       local n = select("#", ...)
       if n > 0 then
          local showt = {}
@@ -3539,8 +3537,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
 
       return {
-         y = t.y,
-         x = t.x,
+         y = where.y,
+         x = where.x,
          msg = msg,
          filename = filename,
       }


### PR DESCRIPTION
Will write docs asap, please look at the tests for now!

TODO:

- [x] union type syntax ( `string | number`)
- [x] `is` operation for runtime matching (`x is number`)
- [x] fix codegen for non-primitive types
- [x] type narrowing in statements (`if  x is number then ... else ... end`)
- [x] type narrowing within expressions (`s = s is string and s:lower()`)

**Edit:** I think the implementation for this first approach towards union types is pretty much ok to merge, but I'd like to call out one important limitation (the text below needs to go into the documentation too):

Since code generation for the `is` operator used for discrimination of
union types translates into a runtime `type()` check, we can only
discriminates across primitive types and at most one table type.

This means that these are valid:

```
local a: string | number | MyRecord
local b: {boolean} | MyEnum
local c: number | {string:number}
```

but these are not valid:

```
local invalid1: MyRecord | MyOtherRecord
local invalid2: {string} | {number}
local invalid3: {string} | {string:string}
local invalid4: {string} | MyRecord
```

Also, since `is` checks for enums currently also translate into
`type()` checks, this means they are indistinguishable from strings
at runtime. So, for now this is also not accepted:

```
local invalid5: string | MyEnum
```

This restriction between strings and enums may be removed in the future.
The restriction on records may also be lifted in the future if we start
registering metatables for them (it may be that a future release may
start supporting unions of records _with_ metatables, if we add a form
of record constructors with metatables).
